### PR TITLE
Add locale config option

### DIFF
--- a/config.go
+++ b/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	username     string
 	password     string
 	runtimePath  string
+	locale       string
 	startTimeout time.Duration
 }
 
@@ -65,6 +66,12 @@ func (c Config) Password(password string) Config {
 // RuntimePath sets the path that will be used for the extracted Postgres runtime and data directory.
 func (c Config) RuntimePath(path string) Config {
 	c.runtimePath = path
+	return c
+}
+
+// Locale sets the default locale for initdb
+func (c Config) Locale(locale string) Config {
+	c.locale = locale
 	return c
 }
 

--- a/embedded_postgres.go
+++ b/embedded_postgres.go
@@ -75,7 +75,7 @@ func (ep *EmbeddedPostgres) Start() error {
 		return fmt.Errorf("unable to extract postgres archive %s to %s", cacheLocation, binaryExtractLocation)
 	}
 
-	if err := ep.initDatabase(binaryExtractLocation, ep.config.username, ep.config.password); err != nil {
+	if err := ep.initDatabase(binaryExtractLocation, ep.config.username, ep.config.password, ep.config.locale); err != nil {
 		return err
 	}
 

--- a/prepare_database.go
+++ b/prepare_database.go
@@ -13,21 +13,28 @@ import (
 	"github.com/lib/pq"
 )
 
-type initDatabase func(binaryExtractLocation, username, password string) error
+type initDatabase func(binaryExtractLocation, username, password, locale string) error
 type createDatabase func(port uint32, username, password, database string) error
 
-func defaultInitDatabase(binaryExtractLocation, username, password string) error {
+func defaultInitDatabase(binaryExtractLocation, username, password, locale string) error {
 	passwordFile, err := createPasswordFile(binaryExtractLocation, password)
 	if err != nil {
 		return err
 	}
 
-	postgresInitDbBinary := filepath.Join(binaryExtractLocation, "bin/initdb")
-	postgresInitDbProcess := exec.Command(postgresInitDbBinary,
+	args := []string{
 		"-A", "password",
 		"-U", username,
 		"-D", filepath.Join(binaryExtractLocation, "data"),
-		fmt.Sprintf("--pwfile=%s", passwordFile))
+		fmt.Sprintf("--pwfile=%s", passwordFile),
+	}
+
+	if locale != "" {
+		args = append(args, fmt.Sprintf("--locale=%s", locale))
+	}
+
+	postgresInitDbBinary := filepath.Join(binaryExtractLocation, "bin/initdb")
+	postgresInitDbProcess := exec.Command(postgresInitDbBinary, args...)
 	postgresInitDbProcess.Stderr = os.Stderr
 	postgresInitDbProcess.Stdout = os.Stdout
 

--- a/prepare_database_test.go
+++ b/prepare_database_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Test_defaultInitDatabase_ErrorWhenCannotCreatePasswordFile(t *testing.T) {
-	err := defaultInitDatabase("path_not_exists", "Tom", "Beer")
+	err := defaultInitDatabase("path_not_exists", "Tom", "Beer", "")
 
 	assert.EqualError(t, err, "unable to write password file to path_not_exists/pwfile")
 }
@@ -28,13 +28,33 @@ func Test_defaultInitDatabase_ErrorWhenCannotStartInitDBProcess(t *testing.T) {
 		}
 	}()
 
-	err = defaultInitDatabase(tempDir, "Tom", "Beer")
+	err = defaultInitDatabase(tempDir, "Tom", "Beer", "")
 
 	assert.EqualError(t, err, fmt.Sprintf("unable to init database using: %s/bin/initdb -A password -U Tom -D %s/data --pwfile=%s/pwfile",
 		tempDir,
 		tempDir,
 		tempDir))
 	assert.FileExists(t, filepath.Join(tempDir, "pwfile"))
+}
+
+func Test_defaultInitDatabase_ErrorInvalidLocaleSetting(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "prepare_database_test")
+	if err != nil {
+		panic(err)
+	}
+
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			panic(err)
+		}
+	}()
+
+	err = defaultInitDatabase(tempDir, "postgres", "postgres", "en_XY")
+
+	assert.EqualError(t, err, fmt.Sprintf("unable to init database using: %s/bin/initdb -A password -U postgres -D %s/data --pwfile=%s/pwfile --locale=en_XY",
+		tempDir,
+		tempDir,
+		tempDir))
 }
 
 func Test_defaultCreateDatabase_ErrorWhenSQLOpenError(t *testing.T) {


### PR DESCRIPTION
This makes the locale of the database created configurable. E.g. for consistent testing where some things depend on the database locale, this is helpful. Or also on broken systems, where the default locale is an invalid string.

I also bumped the versions to the latest point releases.