### PR TITLE
⭐️ alpine binary support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,19 @@ jobs:
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: GO111MODULE=off go get github.com/mattn/goveralls && $(go env GOPATH)/bin/goveralls -v -coverprofile=coverage.out -service=github
+  alpine_tests:
+    name: Alpine Linux Platform Tests
+    runs-on: ubuntu-latest
+    container:
+      image: golang:1.13-alpine
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set Up
+        run: |
+          apk add --upgrade gcc g++ && \
+          adduser testuser -D
+      - name: All Tests
+        run: su - testuser -c 'cd /__w/embedded-postgres/embedded-postgres && /usr/local/go/bin/go test -v ./... && cd platform-test && go test -v ./...'
   platform_tests:
     name: Platform tests
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
           apk add --upgrade gcc g++ && \
           adduser testuser -D
       - name: All Tests
-        run: su - testuser -c 'cd /__w/embedded-postgres/embedded-postgres && /usr/local/go/bin/go test -v ./... && cd platform-test && go test -v ./...'
+        run: su - testuser -c 'export PATH=$PATH:/usr/local/go/bin; cd /__w/embedded-postgres/embedded-postgres && go test -v ./... && cd platform-test && go test -v ./...'
   platform_tests:
     name: Platform tests
     strategy:

--- a/version_strategy.go
+++ b/version_strategy.go
@@ -1,6 +1,9 @@
 package embeddedpostgres
 
-import "runtime"
+import (
+	"os"
+	"runtime"
+)
 
 // VersionStrategy provides a strategy that can be used to determine which version of Postgres should be used based on
 // the operating system, architecture and desired Postgres version.
@@ -8,6 +11,16 @@ type VersionStrategy func() (operatingSystem string, architecture string, postgr
 
 func defaultVersionStrategy(config Config) VersionStrategy {
 	return func() (operatingSystem, architecture string, version PostgresVersion) {
-		return runtime.GOOS, runtime.GOARCH, config.version
+		goos := runtime.GOOS
+		arch := runtime.GOARCH
+
+		// use alpine specific build
+		if goos == "linux" {
+			if _, err := os.Stat("/etc/alpine-release"); err == nil {
+				arch += "-alpine"
+			}
+		}
+
+		return goos, arch, config.version
 	}
 }


### PR DESCRIPTION
This handles the special case for alpine to support embedded-postgres to be able to run in golang:1.16-alpine