### PR TITLE
version strategy: zonkio's arm arch name are different from GOOARCH

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,12 @@ executors:
   linux:
     machine:
       image: ubuntu-2004:202104-01
-    working_directory: /go/src/github.com/fergusstrange/embedded-postgres
+    working_directory: /home/circleci/go/src/github.com/fergusstrange/embedded-postgres
   linux-arm64:
     machine:
       image: ubuntu-2004:202104-01
     resource_class: arm.medium
-    working_directory: /go/src/github.com/fergusstrange/embedded-postgres
+    working_directory: /home/circleci/go/src/github.com/fergusstrange/embedded-postgres
 
 jobs:
   platform_test:
@@ -20,12 +20,12 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - embedded-postgres-{{ checksum "/go/src/github.com/fergusstrange/embedded-postgres/go.mod" }}
+            - embedded-postgres-{{ checksum "/home/circleci/go/src/github.com/fergusstrange/embedded-postgres/go.mod" }}
       - run: cd platform-test && go test -v -race ./...
       - save_cache:
-          key: embedded-postgres-{{ checksum "/go/src/github.com/fergusstrange/embedded-postgres/go.mod" }}
+          key: embedded-postgres-{{ checksum "/home/circleci/go/src/github.com/fergusstrange/embedded-postgres/go.mod" }}
           paths:
-            - /go/pkg
+            - /home/circleci/go/pkg
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,5 @@
 version: 2.1
 executors:
-  linux:
-    machine:
-      image: ubuntu-2004:202104-01
-    working_directory: /home/circleci/go/src/github.com/fergusstrange/embedded-postgres
   linux-arm64:
     machine:
       image: ubuntu-2004:202104-01
@@ -34,4 +30,4 @@ workflows:
       - platform_test:
           matrix:
             parameters:
-              executor: [ linux, linux-arm64 ]
+              executor: [ linux-arm64 ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,6 @@ executors:
       image: ubuntu-2004:202104-01
     resource_class: arm.medium
     working_directory: /go/src/github.com/fergusstrange/embedded-postgres
-  osx:
-    macos:
-      xcode: 11.4
-    working_directory: /go/src/github.com/fergusstrange/embedded-postgres
 
 jobs:
   platform_test:
@@ -38,4 +34,4 @@ workflows:
       - platform_test:
           matrix:
             parameters:
-              executor: [ linux, linux-arm64, osx ]
+              executor: [ linux, linux-arm64 ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
 jobs:
   platform_test:
     parameters:
-      os:
+      executor:
         type: executor
     executor: << parameters.executor >>
     steps:


### PR DESCRIPTION
on arm (32bit), use 'uname -m' to get the excact arm version