### PR TITLE
Add a BinariesPath configuration option, for prefetching Postgres binaries before the test

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This library aims to require as little configuration as possible, favouring over
 | Version        | 12.1.0                                          |
 | RuntimePath    | $USER_HOME/.embedded-postgres-go/extracted      |
 | DataPath       | $USER_HOME/.embedded-postgres-go/extracted/data |
+| BinariesPath   | $USER_HOME/.embedded-postgres-go/extracted      |
 | Port           | 5432                                            |
 | StartTimeout   | 15 Seconds                                      |
 
@@ -53,6 +54,12 @@ If a persistent data location is required, set *DataPath* to a directory outside
 
 If the *RuntimePath* directory is empty or already initialized but with an incompatible postgres version, it will be
 removed and Postgres reinitialized.
+
+Postgres binaries will be downloaded and placed in *BinaryPath* if `BinaryPath/bin` doesn't exist.
+If the directory does exist, whatever binary version is placed there will be used (no version check
+is done).  
+If your test need to run multiple different versions of Postgres for different tests, make sure
+*BinaryPath* is a subdirectory of *RuntimePath*.
 
 A single Postgres instance can be created, started and stopped as follows
 

--- a/config.go
+++ b/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	password     string
 	runtimePath  string
 	dataPath     string
+	binariesPath string
 	locale       string
 	startTimeout time.Duration
 	logger       io.Writer
@@ -81,6 +82,13 @@ func (c Config) RuntimePath(path string) Config {
 // If this option is set, a previously initialized data directory will be reused if possible.
 func (c Config) DataPath(path string) Config {
 	c.dataPath = path
+	return c
+}
+
+// BinariesPath sets the path of the pre-downloaded postgres binaries.
+// If this option is left unset, the binaries will be downloaded.
+func (c Config) BinariesPath(path string) Config {
+	c.binariesPath = path
 	return c
 }
 

--- a/embedded_postgres.go
+++ b/embedded_postgres.go
@@ -97,7 +97,7 @@ func (ep *EmbeddedPostgres) Start() error {
 			return fmt.Errorf("unable to clean up data directory %s with error: %s", ep.config.dataPath, err)
 		}
 
-		if err := ep.initDatabase(ep.config.runtimePath, ep.config.dataPath, ep.config.username, ep.config.password, ep.config.locale, ep.config.logger); err != nil {
+		if err := ep.initDatabase(ep.config.runtimePath, ep.config.runtimePath, ep.config.dataPath, ep.config.username, ep.config.password, ep.config.locale, ep.config.logger); err != nil {
 			return err
 		}
 	}

--- a/embedded_postgres.go
+++ b/embedded_postgres.go
@@ -82,10 +82,6 @@ func (ep *EmbeddedPostgres) Start() error {
 		return fmt.Errorf("unable to clean up runtime directory %s with error: %s", ep.config.runtimePath, err)
 	}
 
-	if err := os.MkdirAll(ep.config.runtimePath, 0755); err != nil {
-		return fmt.Errorf("unable to create runtime directory %s with error: %s", ep.config.runtimePath, err)
-	}
-
 	if ep.config.binariesPath == "" {
 		ep.config.binariesPath = ep.config.runtimePath
 	}
@@ -101,6 +97,10 @@ func (ep *EmbeddedPostgres) Start() error {
 		if err := archiver.NewTarXz().Unarchive(cacheLocation, ep.config.binariesPath); err != nil {
 			return fmt.Errorf("unable to extract postgres archive %s to %s", cacheLocation, ep.config.binariesPath)
 		}
+	}
+
+	if err := os.MkdirAll(ep.config.runtimePath, 0755); err != nil {
+		return fmt.Errorf("unable to create runtime directory %s with error: %s", ep.config.runtimePath, err)
 	}
 
 	reuseData := dataDirIsValid(ep.config.dataPath, ep.config.version)

--- a/embedded_postgres.go
+++ b/embedded_postgres.go
@@ -75,30 +75,34 @@ func (ep *EmbeddedPostgres) Start() error {
 		}
 	}
 
-	binaryExtractLocation := userRuntimePathOrDefault(ep.config.runtimePath, cacheLocation)
-	if err := os.RemoveAll(binaryExtractLocation); err != nil {
-		return fmt.Errorf("unable to clean up runtime directory %s with error: %s", binaryExtractLocation, err)
+	if ep.config.runtimePath == "" {
+		ep.config.runtimePath = filepath.Join(filepath.Dir(cacheLocation), "extracted")
+	}
+	if ep.config.dataPath == "" {
+		ep.config.dataPath = filepath.Join(ep.config.runtimePath, "data")
 	}
 
-	if err := archiver.NewTarXz().Unarchive(cacheLocation, binaryExtractLocation); err != nil {
-		return fmt.Errorf("unable to extract postgres archive %s to %s", cacheLocation, binaryExtractLocation)
+	if err := os.RemoveAll(ep.config.runtimePath); err != nil {
+		return fmt.Errorf("unable to clean up runtime directory %s with error: %s", ep.config.runtimePath, err)
 	}
 
-	dataLocation := userDataPathOrDefault(ep.config.dataPath, binaryExtractLocation)
+	if err := archiver.NewTarXz().Unarchive(cacheLocation, ep.config.runtimePath); err != nil {
+		return fmt.Errorf("unable to extract postgres archive %s to %s", cacheLocation, ep.config.runtimePath)
+	}
 
-	reuseData := ep.config.dataPath != "" && dataDirIsValid(dataLocation, ep.config.version)
+	reuseData := dataDirIsValid(ep.config.dataPath, ep.config.version)
 
 	if !reuseData {
-		if err := os.RemoveAll(dataLocation); err != nil {
-			return fmt.Errorf("unable to clean up data directory %s with error: %s", dataLocation, err)
+		if err := os.RemoveAll(ep.config.dataPath); err != nil {
+			return fmt.Errorf("unable to clean up data directory %s with error: %s", ep.config.dataPath, err)
 		}
 
-		if err := ep.initDatabase(binaryExtractLocation, dataLocation, ep.config.username, ep.config.password, ep.config.locale, ep.config.logger); err != nil {
+		if err := ep.initDatabase(ep.config.runtimePath, ep.config.dataPath, ep.config.username, ep.config.password, ep.config.locale, ep.config.logger); err != nil {
 			return err
 		}
 	}
 
-	if err := startPostgres(binaryExtractLocation, ep.config); err != nil {
+	if err := startPostgres(ep.config); err != nil {
 		return err
 	}
 
@@ -106,7 +110,7 @@ func (ep *EmbeddedPostgres) Start() error {
 
 	if !reuseData {
 		if err := ep.createDatabase(ep.config.port, ep.config.username, ep.config.password, ep.config.database); err != nil {
-			if stopErr := stopPostgres(binaryExtractLocation, ep.config); stopErr != nil {
+			if stopErr := stopPostgres(ep.config); stopErr != nil {
 				return fmt.Errorf("unable to stop database casused by error %s", err)
 			}
 
@@ -115,7 +119,7 @@ func (ep *EmbeddedPostgres) Start() error {
 	}
 
 	if err := healthCheckDatabaseOrTimeout(ep.config); err != nil {
-		if stopErr := stopPostgres(binaryExtractLocation, ep.config); stopErr != nil {
+		if stopErr := stopPostgres(ep.config); stopErr != nil {
 			return fmt.Errorf("unable to stop database casused by error %s", err)
 		}
 
@@ -127,13 +131,11 @@ func (ep *EmbeddedPostgres) Start() error {
 
 // Stop will try to stop the Postgres process gracefully returning an error when there were any problems.
 func (ep *EmbeddedPostgres) Stop() error {
-	cacheLocation, exists := ep.cacheLocator()
-	if !exists || !ep.started {
+	if !ep.started {
 		return errors.New("server has not been started")
 	}
 
-	binaryExtractLocation := userRuntimePathOrDefault(ep.config.runtimePath, cacheLocation)
-	if err := stopPostgres(binaryExtractLocation, ep.config); err != nil {
+	if err := stopPostgres(ep.config); err != nil {
 		return err
 	}
 
@@ -142,10 +144,10 @@ func (ep *EmbeddedPostgres) Stop() error {
 	return nil
 }
 
-func startPostgres(binaryExtractLocation string, config Config) error {
-	postgresBinary := filepath.Join(binaryExtractLocation, "bin/pg_ctl")
+func startPostgres(config Config) error {
+	postgresBinary := filepath.Join(config.runtimePath, "bin/pg_ctl")
 	postgresProcess := exec.Command(postgresBinary, "start", "-w",
-		"-D", userDataPathOrDefault(config.dataPath, binaryExtractLocation),
+		"-D", config.dataPath,
 		"-o", fmt.Sprintf(`"-p %d"`, config.port))
 	postgresProcess.Stderr = config.logger
 	postgresProcess.Stdout = config.logger
@@ -157,10 +159,10 @@ func startPostgres(binaryExtractLocation string, config Config) error {
 	return nil
 }
 
-func stopPostgres(binaryExtractLocation string, config Config) error {
-	postgresBinary := filepath.Join(binaryExtractLocation, "bin/pg_ctl")
+func stopPostgres(config Config) error {
+	postgresBinary := filepath.Join(config.runtimePath, "bin/pg_ctl")
 	postgresProcess := exec.Command(postgresBinary, "stop", "-w",
-		"-D", userDataPathOrDefault(config.dataPath, binaryExtractLocation))
+		"-D", config.dataPath)
 	postgresProcess.Stderr = config.logger
 	postgresProcess.Stdout = config.logger
 
@@ -178,22 +180,6 @@ func ensurePortAvailable(port uint32) error {
 	}
 
 	return nil
-}
-
-func userRuntimePathOrDefault(userLocation, cacheLocation string) string {
-	if userLocation != "" {
-		return userLocation
-	}
-
-	return filepath.Join(filepath.Dir(cacheLocation), "extracted")
-}
-
-func userDataPathOrDefault(userLocation, runtimeLocation string) string {
-	if userLocation != "" {
-		return userLocation
-	}
-
-	return filepath.Join(runtimeLocation, "data")
 }
 
 func dataDirIsValid(dataDir string, version PostgresVersion) bool {

--- a/embedded_postgres.go
+++ b/embedded_postgres.go
@@ -73,6 +73,7 @@ func (ep *EmbeddedPostgres) Start() error {
 	if ep.config.runtimePath == "" {
 		ep.config.runtimePath = filepath.Join(filepath.Dir(cacheLocation), "extracted")
 	}
+
 	if ep.config.dataPath == "" {
 		ep.config.dataPath = filepath.Join(ep.config.runtimePath, "data")
 	}
@@ -80,6 +81,7 @@ func (ep *EmbeddedPostgres) Start() error {
 	if err := os.RemoveAll(ep.config.runtimePath); err != nil {
 		return fmt.Errorf("unable to clean up runtime directory %s with error: %s", ep.config.runtimePath, err)
 	}
+
 	if err := os.MkdirAll(ep.config.runtimePath, 0755); err != nil {
 		return fmt.Errorf("unable to create runtime directory %s with error: %s", ep.config.runtimePath, err)
 	}
@@ -87,6 +89,7 @@ func (ep *EmbeddedPostgres) Start() error {
 	if ep.config.binariesPath == "" {
 		ep.config.binariesPath = ep.config.runtimePath
 	}
+
 	_, binDirErr := os.Stat(filepath.Join(ep.config.binariesPath, "bin"))
 	if os.IsNotExist(binDirErr) {
 		if !cacheExists {

--- a/embedded_postgres_test.go
+++ b/embedded_postgres_test.go
@@ -482,6 +482,7 @@ func Test_PrefetchedBinaries(t *testing.T) {
 	if err := database.remoteFetchStrategy(); err != nil {
 		panic(err)
 	}
+
 	cacheLocation, _ := database.cacheLocator()
 	if err := archiver.NewTarXz().Unarchive(cacheLocation, tempDir); err != nil {
 		panic(err)

--- a/embedded_postgres_test.go
+++ b/embedded_postgres_test.go
@@ -465,18 +465,29 @@ func Test_CustomBinariesLocation(t *testing.T) {
 }
 
 func Test_PrefetchedBinaries(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "prepare_database_test")
+	binTempDir, err := ioutil.TempDir("", "prepare_database_test_bin")
+	if err != nil {
+		panic(err)
+	}
+
+	runtimeTempDir, err := ioutil.TempDir("", "prepare_database_test_runtime")
 	if err != nil {
 		panic(err)
 	}
 
 	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
+		if err := os.RemoveAll(binTempDir); err != nil {
+			panic(err)
+		}
+
+		if err := os.RemoveAll(runtimeTempDir); err != nil {
 			panic(err)
 		}
 	}()
 
-	database := NewDatabase(DefaultConfig().BinariesPath(tempDir))
+	database := NewDatabase(DefaultConfig().
+		BinariesPath(binTempDir).
+		RuntimePath(runtimeTempDir))
 
 	// Download and unarchive postgres into the bindir.
 	if err := database.remoteFetchStrategy(); err != nil {
@@ -484,7 +495,7 @@ func Test_PrefetchedBinaries(t *testing.T) {
 	}
 
 	cacheLocation, _ := database.cacheLocator()
-	if err := archiver.NewTarXz().Unarchive(cacheLocation, tempDir); err != nil {
+	if err := archiver.NewTarXz().Unarchive(cacheLocation, binTempDir); err != nil {
 		panic(err)
 	}
 

--- a/embedded_postgres_test.go
+++ b/embedded_postgres_test.go
@@ -488,7 +488,7 @@ func Test_PrefetchedBinaries(t *testing.T) {
 		panic(err)
 	}
 
-	// Expect everything to work without cacheLocator and/orr remoteFetch abilities.
+	// Expect everything to work without cacheLocator and/or remoteFetch abilities.
 	database.cacheLocator = func() (string, bool) {
 		return "", false
 	}

--- a/embedded_postgres_test.go
+++ b/embedded_postgres_test.go
@@ -118,7 +118,7 @@ func Test_ErrorWhenUnableToInitDatabase(t *testing.T) {
 		return jarFile, true
 	}
 
-	database.initDatabase = func(binaryExtractLocation, dataLocation, username, password, locale string, logger io.Writer) error {
+	database.initDatabase = func(binaryExtractLocation, runtimePath, dataLocation, username, password, locale string, logger io.Writer) error {
 		return errors.New("ah it did not work")
 	}
 
@@ -221,7 +221,7 @@ func Test_ErrorWhenCannotStartPostgresProcess(t *testing.T) {
 		return jarFile, true
 	}
 
-	database.initDatabase = func(binaryExtractLocation, dataLocation, username, password, locale string, logger io.Writer) error {
+	database.initDatabase = func(binaryExtractLocation, runtimePath, dataLocation, username, password, locale string, logger io.Writer) error {
 		return nil
 	}
 

--- a/embedded_postgres_test.go
+++ b/embedded_postgres_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mholt/archiver/v3"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -417,6 +418,84 @@ func Test_ReuseData(t *testing.T) {
 	}
 
 	if err := db.Close(); err != nil {
+		shutdownDBAndFail(t, err, database)
+	}
+
+	if err := database.Stop(); err != nil {
+		shutdownDBAndFail(t, err, database)
+	}
+}
+
+func Test_CustomBinariesLocation(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "prepare_database_test")
+	if err != nil {
+		panic(err)
+	}
+
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			panic(err)
+		}
+	}()
+
+	database := NewDatabase(DefaultConfig().
+		BinariesPath(tempDir))
+
+	if err := database.Start(); err != nil {
+		shutdownDBAndFail(t, err, database)
+	}
+
+	if err := database.Stop(); err != nil {
+		shutdownDBAndFail(t, err, database)
+	}
+
+	// Delete cache to make sure unarchive doesn't happen again.
+	cacheLocation, _ := database.cacheLocator()
+	if err := os.RemoveAll(cacheLocation); err != nil {
+		panic(err)
+	}
+
+	if err := database.Start(); err != nil {
+		shutdownDBAndFail(t, err, database)
+	}
+
+	if err := database.Stop(); err != nil {
+		shutdownDBAndFail(t, err, database)
+	}
+}
+
+func Test_PrefetchedBinaries(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "prepare_database_test")
+	if err != nil {
+		panic(err)
+	}
+
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			panic(err)
+		}
+	}()
+
+	database := NewDatabase(DefaultConfig().BinariesPath(tempDir))
+
+	// Download and unarchive postgres into the bindir.
+	if err := database.remoteFetchStrategy(); err != nil {
+		panic(err)
+	}
+	cacheLocation, _ := database.cacheLocator()
+	if err := archiver.NewTarXz().Unarchive(cacheLocation, tempDir); err != nil {
+		panic(err)
+	}
+
+	// Expect everything to work without cacheLocator and/orr remoteFetch abilities.
+	database.cacheLocator = func() (string, bool) {
+		return "", false
+	}
+	database.remoteFetchStrategy = func() error {
+		return errors.New("did not work")
+	}
+
+	if err := database.Start(); err != nil {
 		shutdownDBAndFail(t, err, database)
 	}
 

--- a/prepare_database.go
+++ b/prepare_database.go
@@ -14,11 +14,11 @@ import (
 	"github.com/lib/pq"
 )
 
-type initDatabase func(binaryExtractLocation, pgDataDir, username, password, locale string, logger io.Writer) error
+type initDatabase func(binaryExtractLocation, runtimePath, pgDataDir, username, password, locale string, logger io.Writer) error
 type createDatabase func(port uint32, username, password, database string) error
 
-func defaultInitDatabase(binaryExtractLocation, pgDataDir, username, password, locale string, logger io.Writer) error {
-	passwordFile, err := createPasswordFile(binaryExtractLocation, password)
+func defaultInitDatabase(binaryExtractLocation, runtimePath, pgDataDir, username, password, locale string, logger io.Writer) error {
+	passwordFile, err := createPasswordFile(runtimePath, password)
 	if err != nil {
 		return err
 	}
@@ -50,8 +50,8 @@ func defaultInitDatabase(binaryExtractLocation, pgDataDir, username, password, l
 	return nil
 }
 
-func createPasswordFile(binaryExtractLocation, password string) (string, error) {
-	passwordFileLocation := filepath.Join(binaryExtractLocation, "pwfile")
+func createPasswordFile(runtimePath, password string) (string, error) {
+	passwordFileLocation := filepath.Join(runtimePath, "pwfile")
 	if err := ioutil.WriteFile(passwordFileLocation, []byte(password), 0600); err != nil {
 		return "", fmt.Errorf("unable to write password file to %s", passwordFileLocation)
 	}

--- a/prepare_database_test.go
+++ b/prepare_database_test.go
@@ -21,6 +21,7 @@ func Test_defaultInitDatabase_ErrorWhenCannotStartInitDBProcess(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
+
 	runtimeTempDir, err := ioutil.TempDir("", "prepare_database_test_runtime")
 	if err != nil {
 		panic(err)
@@ -30,6 +31,7 @@ func Test_defaultInitDatabase_ErrorWhenCannotStartInitDBProcess(t *testing.T) {
 		if err := os.RemoveAll(binTempDir); err != nil {
 			panic(err)
 		}
+
 		if err := os.RemoveAll(runtimeTempDir); err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Downloading and Un-archiving the postgres binaries is slow and flaky in some CI systems.
For example - in my case, our CI system starts a fresh sandbox for every test it runs, and as such caching the downloaded postgres file is impossible.
Even when it is possible to cache the downloaded file, it's still might be slow due to the time it takes to unarchive it.

The change in this PR does the following:
It gives an option to specify a binaries path, where the binaries will be unarchived to, and will not get deleted between tests.
If the `BinariesPath/bin` directory exists, the system will assume files were pre-downloaded, and will not try to fetch/unarchive them.

The PR is split into 4 commits:
1. Refactor of the usage of the folders, in order to not "recalculate" the data/runtime directories over and over again (makes code simpler)
2. Separates the variable holding the runtimePath from the one holding the binaryExtractLocation (as those can now be different).
3. Adds the BinariesPath to the configuration, and adds the logic to reuse unarchived binaries (as well as adds new tests)
4. Updates README (documentation)

This change should be fully backward compatible if `BinariesPath` is not specified.

This also helps with #35 (@mbfr).