### PR TITLE
Add running binaries with specific attributes

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package embeddedpostgres
 import (
 	"io"
 	"os"
+	"syscall"
 	"time"
 )
 
@@ -19,6 +20,7 @@ type Config struct {
 	locale       string
 	startTimeout time.Duration
 	logger       io.Writer
+	procAttr     *syscall.SysProcAttr
 }
 
 // DefaultConfig provides a default set of configuration to be used "as is" or modified using the provided builders.

--- a/embedded_postgres.go
+++ b/embedded_postgres.go
@@ -153,7 +153,7 @@ func (ep *EmbeddedPostgres) cleanDataDirectoryAndInit() error {
 		return fmt.Errorf("unable to clean up data directory %s with error: %s", ep.config.dataPath, err)
 	}
 
-	if err := ep.initDatabase(ep.config.binariesPath, ep.config.runtimePath, ep.config.dataPath, ep.config.username, ep.config.password, ep.config.locale, ep.syncedLogger.file); err != nil {
+	if err := ep.initDatabase(ep.config.procAttr, ep.config.binariesPath, ep.config.runtimePath, ep.config.dataPath, ep.config.username, ep.config.password, ep.config.locale, ep.syncedLogger.file); err != nil {
 		return err
 	}
 
@@ -184,6 +184,9 @@ func startPostgres(ep *EmbeddedPostgres) error {
 	postgresProcess := exec.Command(postgresBinary, "start", "-w",
 		"-D", ep.config.dataPath,
 		"-o", fmt.Sprintf(`"-p %d"`, ep.config.port))
+
+	postgresProcess.SysProcAttr = ep.config.procAttr
+
 	postgresProcess.Stdout = ep.syncedLogger.file
 	postgresProcess.Stderr = ep.syncedLogger.file
 
@@ -198,6 +201,9 @@ func stopPostgres(ep *EmbeddedPostgres) error {
 	postgresBinary := filepath.Join(ep.config.binariesPath, "bin/pg_ctl")
 	postgresProcess := exec.Command(postgresBinary, "stop", "-w",
 		"-D", ep.config.dataPath)
+
+	postgresProcess.SysProcAttr = ep.config.procAttr
+
 	postgresProcess.Stderr = ep.syncedLogger.file
 	postgresProcess.Stdout = ep.syncedLogger.file
 

--- a/embedded_postgres_test.go
+++ b/embedded_postgres_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -121,7 +122,7 @@ func Test_ErrorWhenUnableToInitDatabase(t *testing.T) {
 		return jarFile, true
 	}
 
-	database.initDatabase = func(binaryExtractLocation, runtimePath, dataLocation, username, password, locale string, logger *os.File) error {
+	database.initDatabase = func(procAttr *syscall.SysProcAttr, binaryExtractLocation, runtimePath, dataLocation, username, password, locale string, logger *os.File) error {
 		return errors.New("ah it did not work")
 	}
 
@@ -224,7 +225,7 @@ func Test_ErrorWhenCannotStartPostgresProcess(t *testing.T) {
 		return jarFile, true
 	}
 
-	database.initDatabase = func(binaryExtractLocation, runtimePath, dataLocation, username, password, locale string, logger *os.File) error {
+	database.initDatabase = func(procAttr *syscall.SysProcAttr, binaryExtractLocation, runtimePath, dataLocation, username, password, locale string, logger *os.File) error {
 		return nil
 	}
 

--- a/prepare_database_test.go
+++ b/prepare_database_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Test_defaultInitDatabase_ErrorWhenCannotCreatePasswordFile(t *testing.T) {
-	err := defaultInitDatabase("path_not_exists", "path_not_exists", "path_not_exists", "Tom", "Beer", "", os.Stderr)
+	err := defaultInitDatabase(nil, "path_not_exists", "path_not_exists", "path_not_exists", "Tom", "Beer", "", os.Stderr)
 
 	assert.EqualError(t, err, "unable to write password file to path_not_exists/pwfile")
 }
@@ -37,12 +37,13 @@ func Test_defaultInitDatabase_ErrorWhenCannotStartInitDBProcess(t *testing.T) {
 		}
 	}()
 
-	err = defaultInitDatabase(binTempDir, runtimeTempDir, filepath.Join(runtimeTempDir, "data"), "Tom", "Beer", "", os.Stderr)
+	err = defaultInitDatabase(nil, binTempDir, runtimeTempDir, filepath.Join(runtimeTempDir, "data"), "Tom", "Beer", "", os.Stderr)
 
-	assert.EqualError(t, err, fmt.Sprintf("unable to init database using: %s/bin/initdb -A password -U Tom -D %s/data --pwfile=%s/pwfile",
+	assert.EqualError(t, err, fmt.Sprintf("unable to init database using: %s/bin/initdb -A password -U Tom -D %s/data --pwfile=%s/pwfile: fork/exec %s/bin/initdb: no such file or directory",
 		binTempDir,
 		runtimeTempDir,
-		runtimeTempDir))
+		runtimeTempDir,
+		binTempDir))
 	assert.FileExists(t, filepath.Join(runtimeTempDir, "pwfile"))
 }
 
@@ -58,9 +59,10 @@ func Test_defaultInitDatabase_ErrorInvalidLocaleSetting(t *testing.T) {
 		}
 	}()
 
-	err = defaultInitDatabase(tempDir, tempDir, filepath.Join(tempDir, "data"), "postgres", "postgres", "en_XY", os.Stderr)
+	err = defaultInitDatabase(nil, tempDir, tempDir, filepath.Join(tempDir, "data"), "postgres", "postgres", "en_XY", os.Stderr)
 
-	assert.EqualError(t, err, fmt.Sprintf("unable to init database using: %s/bin/initdb -A password -U postgres -D %s/data --pwfile=%s/pwfile --locale=en_XY",
+	assert.EqualError(t, err, fmt.Sprintf("unable to init database using: %s/bin/initdb -A password -U postgres -D %s/data --pwfile=%s/pwfile --locale=en_XY: fork/exec %s/bin/initdb: no such file or directory",
+		tempDir,
 		tempDir,
 		tempDir,
 		tempDir))

--- a/proc_attr.go
+++ b/proc_attr.go
@@ -1,0 +1,14 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package embeddedpostgres
+
+import (
+	"syscall"
+)
+
+// ProcAttr sets custom attributes for the embedded postgres process
+func (c Config) ProcAttr(procAttr *syscall.SysProcAttr) Config {
+	c.procAttr = procAttr
+	return c
+}

--- a/proc_attr_test.go
+++ b/proc_attr_test.go
@@ -1,0 +1,114 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package embeddedpostgres
+
+import (
+	"database/sql"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_RunAsUser(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "embedded_postgres_test")
+	require.NoError(t, err)
+
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			panic(err)
+		}
+	}()
+
+	current, err := user.Current()
+	require.NoError(t, err)
+	uid, err := strconv.ParseInt(current.Uid, 10, 64)
+	require.NoError(t, err)
+	gid, err := strconv.ParseInt(current.Gid, 10, 64)
+	require.NoError(t, err)
+
+	t.Logf("Running as %d/%d", uid, gid)
+
+	database := NewDatabase(DefaultConfig().
+		ProcAttr(
+			&syscall.SysProcAttr{
+				Credential: &syscall.Credential{
+					Uid:         uint32(uid),
+					Gid:         uint32(gid),
+					NoSetGroups: true,
+				},
+			},
+		).
+		Username("gin").
+		Password("wine").
+		Database("beer").
+		Version(V12).
+		RuntimePath(tempDir).
+		Port(9876).
+		StartTimeout(10 * time.Second).
+		Locale("C").
+		Logger(nil),
+	)
+
+	if err := database.Start(); err != nil {
+		shutdownDBAndFail(t, err, database)
+	}
+
+	db, err := sql.Open("postgres", "host=localhost port=9876 user=gin password=wine dbname=beer sslmode=disable")
+	if err != nil {
+		shutdownDBAndFail(t, err, database)
+	}
+
+	if err = db.Ping(); err != nil {
+		shutdownDBAndFail(t, err, database)
+	}
+
+	if err := db.Close(); err != nil {
+		shutdownDBAndFail(t, err, database)
+	}
+
+	if err := database.Stop(); err != nil {
+		shutdownDBAndFail(t, err, database)
+	}
+}
+
+func Test_RunAsNonexistentUser(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "embedded_postgres_test")
+	require.NoError(t, err)
+
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			panic(err)
+		}
+	}()
+
+	database := NewDatabase(DefaultConfig().
+		ProcAttr(
+			&syscall.SysProcAttr{
+				Credential: &syscall.Credential{
+					Uid: uint32(100000),
+					Gid: uint32(94959495),
+				},
+			},
+		).
+		Username("gin").
+		Password("wine").
+		Database("beer").
+		Version(V12).
+		RuntimePath(tempDir).
+		Port(9876).
+		StartTimeout(10 * time.Second).
+		Locale("C").
+		Logger(nil),
+	)
+
+	err = database.Start()
+	assert.Error(t, err)
+}


### PR DESCRIPTION
I have a simple use case where I just want to be able to run the spawned postgres binaries with some specific atttributes (specifically, in CI where I can't stop the CI container running as root, which postgres doesn't like). This adds an extra configuration option to allow specified a `SysProcAttr` setting for the commands which are spawned when the database is started/stopped/etc. This is only exposed on targets which actually support it (ie, not Windows).

I've included an example of how to use it to run the binaries as a specific user.

I'm not sure how to document this because it's not a setting that most people will ever want to use, it's only available on some platforms, and it's quite low level. Is it sensible to add another sub-section into the README explaining it rather than adding it to the existing table of configuration options?