### PR TITLE
Added V14 (14.1.0) supported version.

### DIFF
--- a/config.go
+++ b/config.go
@@ -115,6 +115,7 @@ type PostgresVersion string
 
 // Predefined supported Postgres versions.
 const (
+	V14 = PostgresVersion("14.1.0")
 	V13 = PostgresVersion("13.4.0")
 	V12 = PostgresVersion("12.8.0")
 	V11 = PostgresVersion("11.13.0")

--- a/platform-test/platform_test.go
+++ b/platform-test/platform_test.go
@@ -13,6 +13,7 @@ import (
 
 func Test_AllMajorVersions(t *testing.T) {
 	allVersions := []embeddedpostgres.PostgresVersion{
+		embeddedpostgres.V14,
 		embeddedpostgres.V13,
 		embeddedpostgres.V12,
 		embeddedpostgres.V11,


### PR DESCRIPTION
Hello! :D
I am working on M1 Mac Air. Embedded postgres using **12.8.0** binary version can run on **M1 Mac**, but in **debug** mode it freezes. Version **14.1.0** is a "Fat" binary - more on that [here](https://github.com/zonkyio/embedded-postgres-binaries/issues/42) - which probably runs still on rosetta(I am not 100% sure) but allowed me to run code using embedded postgres in debug mode on my M1 Mac