### PR TITLE
Add CachePath as a configuration option 

### DIFF
--- a/cache_locator.go
+++ b/cache_locator.go
@@ -10,11 +10,13 @@ import (
 // The result of whether this cache is present will be returned to exists.
 type CacheLocator func() (location string, exists bool)
 
-func defaultCacheLocator(versionStrategy VersionStrategy) CacheLocator {
+func defaultCacheLocator(cacheDirectory string, versionStrategy VersionStrategy) CacheLocator {
 	return func() (string, bool) {
-		cacheDirectory := ".embedded-postgres-go"
-		if userHome, err := os.UserHomeDir(); err == nil {
-			cacheDirectory = filepath.Join(userHome, ".embedded-postgres-go")
+		if cacheDirectory == "" {
+			cacheDirectory = ".embedded-postgres-go"
+			if userHome, err := os.UserHomeDir(); err == nil {
+				cacheDirectory = filepath.Join(userHome, ".embedded-postgres-go")
+			}
 		}
 
 		operatingSystem, architecture, version := versionStrategy()

--- a/cache_locator_test.go
+++ b/cache_locator_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func Test_defaultCacheLocator_NotExists(t *testing.T) {
-	locator := defaultCacheLocator(func() (string, string, PostgresVersion) {
+	locator := defaultCacheLocator("", func() (string, string, PostgresVersion) {
 		return "a", "b", "1.2.3"
 	})
 

--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	runtimePath         string
 	dataPath            string
 	binariesPath        string
+	cachePath           string
 	locale              string
 	binaryRepositoryURL string
 	startTimeout        time.Duration
@@ -91,6 +92,13 @@ func (c Config) DataPath(path string) Config {
 // If this option is left unset, the binaries will be downloaded.
 func (c Config) BinariesPath(path string) Config {
 	c.binariesPath = path
+	return c
+}
+
+// CachePath sets the path of pre-downloaded postgres cached archives.
+// If this option is left unset, a default cache in the $HOME will be used.
+func (c Config) CachePath(path string) Config {
+	c.cachePath = path
 	return c
 }
 

--- a/embedded_postgres.go
+++ b/embedded_postgres.go
@@ -42,7 +42,7 @@ func newDatabaseWithConfig(config Config) *EmbeddedPostgres {
 		linuxMachineName,
 		shouldUseAlpineLinuxBuild,
 	)
-	cacheLocator := defaultCacheLocator(versionStrategy)
+	cacheLocator := defaultCacheLocator(config.cachePath, versionStrategy)
 	remoteFetchStrategy := defaultRemoteFetchStrategy(config.binaryRepositoryURL, versionStrategy, cacheLocator)
 
 	return &EmbeddedPostgres{


### PR DESCRIPTION
This allows a configurable cache path to store postgres archives.
Callers can centralize the location of all data stored by this
library with this change.