### PR TITLE
Own the postgres process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,78 +9,94 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        id: go
-        uses: actions/checkout@v1
-      - name: Set Up Golang
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.13
-      - name: Check Dependencies
-        run: |
-          go list -json -deps > go.list
-          for d in "." "examples" "platform-test"; do
-            pushd $d
-            go mod tidy
-            if [ ! -z "$(git status --porcelain go.mod)" ]; then
-              printf "go.mod has modifications\n"
-              git diff go.mod
-              exit 1
-            fi
-            if [ ! -z "$(git status --porcelain go.sum)" ]; then
-              printf "go.sum has modifications\n"
-              git diff go.sum
-              exit 1
-            fi
-            popd
-          done;
-      - name: Nancy Vulnerability
-        uses: sonatype-nexus-community/nancy-github-action@main
-        with:
-          nancyVersion: v1.0.36
-          nancyCommand: sleuth
-      - name: GolangCI Lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.1
-          /home/runner/go/bin/golangci-lint run
-      - name: Test
-        run: go test -v -test.timeout 0 -race -cover -covermode=atomic -coverprofile=coverage.out ./...
-      - name: Test Examples
-        run: |
-          pushd examples && \
-          go test -v ./... && \
+    - name: Checkout
+      id: go
+      uses: actions/checkout@v1
+    - name: Set Up Golang
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+    - name: Check Dependencies
+      run: |
+        go list -json -deps > go.list
+        for d in "." "examples" "platform-test"; do
+          pushd $d
+          go mod tidy
+          if [ ! -z "$(git status --porcelain go.mod)" ]; then
+            printf "go.mod has modifications\n"
+            git diff go.mod
+            exit 1
+          fi
+          if [ ! -z "$(git status --porcelain go.sum)" ]; then
+            printf "go.sum has modifications\n"
+            git diff go.sum
+            exit 1
+          fi
           popd
-      - name: Upload Coverage Report
-        env:
-          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: GO111MODULE=off go get github.com/mattn/goveralls && $(go env GOPATH)/bin/goveralls -v -coverprofile=coverage.out -service=github
+        done;
+    - name: Nancy Vulnerability
+      uses: sonatype-nexus-community/nancy-github-action@main
+      with:
+        nancyVersion: v1.0.36
+        nancyCommand: sleuth
+    - name: GolangCI Lint
+      run: |
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.1
+        /home/runner/go/bin/golangci-lint run
+    - name: Test
+      run: go test -v -test.timeout 0 -race -cover -covermode=atomic -coverprofile=coverage.out ./...
+    - name: Test Examples
+      run: |
+        pushd examples && \
+        go test -v ./... && \
+        popd
+    - name: Upload Coverage Report
+      env:
+        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: GO111MODULE=off go get github.com/mattn/goveralls && $(go env GOPATH)/bin/goveralls -v -coverprofile=coverage.out -service=github
   alpine_tests:
     name: Alpine Linux Platform Tests
     runs-on: ubuntu-latest
     container:
       image: golang:1.13-alpine
     steps:
-      - uses: actions/checkout@v1
-      - name: Set Up
-        run: |
-          apk add --upgrade gcc g++ && \
-          adduser testuser -D
-      - name: All Tests
-        run: su - testuser -c 'export PATH=$PATH:/usr/local/go/bin; cd /__w/embedded-postgres/embedded-postgres && go test -v ./... && cd platform-test && go test -v ./...'
+    - uses: actions/checkout@v1
+    - name: Set Up
+      run: |
+        apk add --upgrade gcc g++ && \
+        adduser testuser -D
+    - name: All Tests
+      run: su - testuser -c 'export PATH=$PATH:/usr/local/go/bin; cd /__w/embedded-postgres/embedded-postgres && go test -v ./... && cd platform-test && go test -v ./...'
+  mac_tests:
+    name: Mac Platform tests
+    runs-on: macos-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Set Up Golang
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+    - name: Platform Tests
+      # MallocNanoZone=0 is from https://github.com/golang/go/issues/49138#issuecomment-951321823
+      # To avoid unknown class issues on Mac using go test -race
+      run: |
+        cd platform-test
+        MallocNanoZone=0 go test -v -race ./...
   platform_tests:
     name: Platform tests
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-      - name: Set Up Golang
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.13
-      - name: Platform Tests
-        run: |
-          cd platform-test
-          go test -v -race ./...
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Set Up Golang
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+    - name: Platform Tests
+      run: |
+        cd platform-test
+        go test -v -race ./...

--- a/embedded_postgres.go
+++ b/embedded_postgres.go
@@ -202,6 +202,7 @@ func startPostgres(ctx context.Context, ep *EmbeddedPostgres) (*exec.Cmd, error)
 		return nil, fmt.Errorf("could not start postgres using %s", postgresProcess.String())
 	}
 
+	_ = ep.syncedLogger.flush()
 	if err := waitForPostmasterReady(ctx, ep.config, 100*time.Millisecond, postgresProcess.Process.Pid); err != nil {
 		if stopErr := postgresProcess.Process.Signal(syscall.SIGINT); stopErr != nil {
 			return nil, fmt.Errorf("unable to stop database casused by error %s", err)

--- a/embedded_postgres.go
+++ b/embedded_postgres.go
@@ -257,6 +257,7 @@ func pgCtlStatus(config Config) (*pgStatus, error) {
 			return nil, fmt.Errorf("%s - %w: %s", cmd.String(), err, buf.String())
 		}
 	}
+
 	status := &pgStatus{Output: buf.String()}
 
 	// scanner to support windows
@@ -268,7 +269,9 @@ func pgCtlStatus(config Config) (*pgStatus, error) {
 		if _, err := fmt.Sscanf(line, "pg_ctl: server is running (PID: %d)", &status.Pid); err != nil {
 			return status, nil
 		}
+
 		status.Running = true
+
 		return status, nil
 	}
 
@@ -285,13 +288,18 @@ func (ep *EmbeddedPostgres) waitForPostmasterReady(ctx context.Context, interval
 			return fmt.Errorf("timed out waiting for database to become available: %w", err)
 		case <-ticker.C:
 			_ = ep.syncedLogger.flush()
+
 			var status *pgStatus
+
 			status, err = pgCtlStatus(ep.config)
+
 			fmt.Println(status)
+
 			if status != nil && status.Running {
 				if status.Pid != ep.cmd.Process.Pid {
 					return fmt.Errorf("process running, but for wrong pid, expected %d, got %d", ep.cmd.Process.Pid, status.Pid)
 				}
+
 				return nil
 			}
 		}

--- a/embedded_postgres.go
+++ b/embedded_postgres.go
@@ -201,6 +201,8 @@ func (ep *EmbeddedPostgres) startPostgres(ctx context.Context) error {
 		return fmt.Errorf("could not start postgres using %s", command.String())
 	}
 
+	ep.cmd = command
+
 	if err := ep.waitForPostmasterReady(ctx, 100*time.Millisecond); err != nil {
 		if stopErr := command.Process.Signal(syscall.SIGINT); stopErr != nil {
 			return fmt.Errorf("unable to stop database casused by error %s", err)
@@ -208,8 +210,6 @@ func (ep *EmbeddedPostgres) startPostgres(ctx context.Context) error {
 
 		return err
 	}
-
-	ep.cmd = command
 
 	return nil
 }

--- a/embedded_postgres.go
+++ b/embedded_postgres.go
@@ -291,9 +291,11 @@ func (ep *EmbeddedPostgres) waitForPostmasterReady(ctx context.Context, interval
 
 			var status *pgStatus
 
-			status, err = pgCtlStatus(ep.config)
+			if ep.cmd.Process == nil {
+				return fmt.Errorf("no process found")
+			}
 
-			fmt.Println(status)
+			status, err = pgCtlStatus(ep.config)
 
 			if status != nil && status.Running {
 				if status.Pid != ep.cmd.Process.Pid {

--- a/embedded_postgres_test.go
+++ b/embedded_postgres_test.go
@@ -1,6 +1,7 @@
 package embeddedpostgres
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -156,7 +157,7 @@ func Test_ErrorWhenUnableToCreateDatabase(t *testing.T) {
 		RuntimePath(extractPath).
 		StartTimeout(10 * time.Second))
 
-	database.createDatabase = func(port uint32, username, password, database string) error {
+	database.createDatabase = func(ctx context.Context, port uint32, username, password, database string) error {
 		return errors.New("ah noes")
 	}
 
@@ -176,7 +177,7 @@ func Test_TimesOutWhenCannotStart(t *testing.T) {
 		Database("something-fancy").
 		StartTimeout(500 * time.Millisecond))
 
-	database.createDatabase = func(port uint32, username, password, database string) error {
+	database.createDatabase = func(ctx context.Context, port uint32, username, password, database string) error {
 		return nil
 	}
 
@@ -232,7 +233,7 @@ func Test_ErrorWhenCannotStartPostgresProcess(t *testing.T) {
 
 	err = database.Start()
 
-	assert.EqualError(t, err, fmt.Sprintf(`could not start postgres using %s/bin/pg_ctl start -w -D %s/data -o "-p 5432"`, extractPath, extractPath))
+	assert.EqualError(t, err, fmt.Sprintf(`could not start postgres using %s/bin/postgres -D %s/data -p 5432`, extractPath, extractPath))
 }
 
 func Test_CustomConfig(t *testing.T) {
@@ -325,9 +326,18 @@ func Test_CustomLog(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, lines, fmt.Sprintf("The files belonging to this database system will be owned by user \"%s\".", current.Username))
 	assert.Contains(t, lines, "syncing data to disk ... ok")
-	assert.Contains(t, lines, "server stopped")
+
+	lastLine := ""
+	for i := len(lines) - 1; i > 0; i-- {
+		lastLine = strings.TrimSpace(lines[i])
+		if len(lastLine) > 0 {
+			break
+		}
+	}
+
+	assert.True(t, strings.HasSuffix(lastLine, "database system is shut down"))
 	assert.Less(t, len(lines), 55)
-	assert.Greater(t, len(lines), 40)
+	assert.Greater(t, len(lines), 36)
 }
 
 func Test_CustomLocaleConfig(t *testing.T) {

--- a/prepare_database.go
+++ b/prepare_database.go
@@ -20,7 +20,7 @@ const (
 )
 
 type initDatabase func(binaryExtractLocation, runtimePath, pgDataDir, username, password, locale string, logger *os.File) error
-type createDatabase func(port uint32, username, password, database string) error
+type createDatabase func(ctx context.Context, port uint32, username, password, database string) error
 
 func defaultInitDatabase(binaryExtractLocation, runtimePath, pgDataDir, username, password, locale string, logger *os.File) error {
 	passwordFile, err := createPasswordFile(runtimePath, password)
@@ -64,7 +64,7 @@ func createPasswordFile(runtimePath, password string) (string, error) {
 	return passwordFileLocation, nil
 }
 
-func defaultCreateDatabase(port uint32, username, password, database string) (err error) {
+func defaultCreateDatabase(ctx context.Context, port uint32, username, password, database string) (err error) {
 	if database == "postgres" {
 		return nil
 	}
@@ -79,7 +79,7 @@ func defaultCreateDatabase(port uint32, username, password, database string) (er
 		err = connectionClose(db, err)
 	}()
 
-	if _, err := db.Exec(fmt.Sprintf("CREATE DATABASE %s", database)); err != nil {
+	if _, err := db.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE %s", database)); err != nil {
 		return errorCustomDatabase(database, err)
 	}
 
@@ -102,17 +102,13 @@ func connectionClose(db io.Closer, err error) error {
 	return err
 }
 
-func healthCheckDatabaseOrTimeout(config Config) error {
+func healthCheckDatabaseOrTimeout(ctx context.Context, config Config) error {
 	healthCheckSignal := make(chan bool)
 
 	defer close(healthCheckSignal)
 
-	timeout, cancelFunc := context.WithTimeout(context.Background(), config.startTimeout)
-
-	defer cancelFunc()
-
 	go func() {
-		for timeout.Err() == nil {
+		for ctx.Err() == nil {
 			if err := healthCheckDatabase(config.port, config.database, config.username, config.password); err != nil {
 				continue
 			}
@@ -125,7 +121,7 @@ func healthCheckDatabaseOrTimeout(config Config) error {
 	select {
 	case <-healthCheckSignal:
 		return nil
-	case <-timeout.Done():
+	case <-ctx.Done():
 		return errors.New("timed out waiting for database to become available")
 	}
 }

--- a/prepare_database_test.go
+++ b/prepare_database_test.go
@@ -1,12 +1,14 @@
 package embeddedpostgres
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -99,7 +101,10 @@ func Test_defaultInitDatabase_PwFileRemoved(t *testing.T) {
 }
 
 func Test_defaultCreateDatabase_ErrorWhenSQLOpenError(t *testing.T) {
-	err := defaultCreateDatabase(1234, "user client_encoding=lol", "password", "database")
+	ctx, cncl := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cncl()
+
+	err := defaultCreateDatabase(ctx, 1234, "user client_encoding=lol", "password", "database")
 
 	assert.EqualError(t, err, "unable to connect to create database with custom name database with the following error: client_encoding must be absent or 'UTF8'")
 }
@@ -118,7 +123,11 @@ func Test_defaultCreateDatabase_ErrorWhenQueryError(t *testing.T) {
 		}
 	}()
 
-	err := defaultCreateDatabase(9831, "postgres", "postgres", "b33r")
+	ctx, cncl := context.WithTimeout(context.Background(), 5*time.Second)
+
+	defer cncl()
+
+	err := defaultCreateDatabase(ctx, 9831, "postgres", "postgres", "b33r")
 
 	assert.EqualError(t, err, `unable to connect to create database with custom name b33r with the following error: pq: database "b33r" already exists`)
 }

--- a/process_unix.go
+++ b/process_unix.go
@@ -1,0 +1,55 @@
+//go:build !windows
+// +build !windows
+
+package embeddedpostgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+func (ep *EmbeddedPostgres) startPostgres(ctx context.Context) error {
+	postgresBinary := filepath.Join(ep.config.binariesPath, "bin/postgres")
+	ep.cmd = exec.Command(postgresBinary,
+		"-D", ep.config.dataPath,
+		"-p", fmt.Sprintf("%d", ep.config.port))
+	ep.cmd.Stdout = ep.syncedLogger.file
+	ep.cmd.Stderr = ep.syncedLogger.file
+
+	if err := ep.cmd.Start(); err != nil {
+		return fmt.Errorf("could not start postgres using %s", ep.cmd.String())
+	}
+
+	if err := ep.waitForPostmasterReady(ctx, 100*time.Millisecond); err != nil {
+		if stopErr := ep.cmd.Process.Signal(syscall.SIGINT); stopErr != nil {
+			return fmt.Errorf("unable to stop database casused by error %s", err)
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+// Stop will try to stop the Postgres process gracefully returning an error when there were any problems.
+func (ep *EmbeddedPostgres) Stop() error {
+	if !ep.started {
+		return errors.New("server has not been started")
+	}
+
+	_ = ep.cmd.Process.Signal(syscall.SIGINT)
+	_ = ep.cmd.Wait()
+
+	ep.started = false
+
+	if err := ep.syncedLogger.flush(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/process_windows.go
+++ b/process_windows.go
@@ -3,7 +3,13 @@
 
 package embeddedpostgres
 
-import "path/filepath"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+)
 
 // startPostgres
 // On Windows, you need to jump through hoops to start the process as a restricted user.

--- a/process_windows.go
+++ b/process_windows.go
@@ -5,26 +5,30 @@ package embeddedpostgres
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os/exec"
 	"path/filepath"
 )
 
-// startPostgres
+type postgresProcess struct {
+	Config Config
+	Logger *syncedLogger
+}
+
+// Start
 // On Windows, you need to jump through hoops to start the process as a restricted user.
 // Postgres won't start as administrator.
 // So for now we just use pg_ctl on Windows since it does the hoop jumping.
-func (ep *EmbeddedPostgres) startPostgres(ctx context.Context) error {
-	pgCtlBinary := filepath.Join(ep.config.binariesPath, "bin/pg_ctl")
-	ep.cmd = exec.Command(pgCtlBinary, "start", "-w",
-		"-D", ep.config.dataPath,
-		"-o", fmt.Sprintf("-p %d", ep.config.port))
-	ep.cmd.Stdout = ep.syncedLogger.file
-	ep.cmd.Stderr = ep.syncedLogger.file
+func (pp *postgresProcess) Start(ctx context.Context) error {
+	pgCtlBinary := filepath.Join(pp.Config.binariesPath, "bin/pg_ctl")
+	cmd := exec.Command(pgCtlBinary, "start", "-w",
+		"-D", pp.Config.dataPath,
+		"-o", fmt.Sprintf("-p %d", pp.Config.port))
+	cmd.Stdout = pp.Logger.file
+	cmd.Stderr = pp.Logger.file
 
-	if err := ep.cmd.Run(); err != nil {
-		return fmt.Errorf("could not start postgres using %s", ep.cmd.String())
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("could not start postgres using %s", cmd.String())
 	}
 
 	return nil
@@ -32,25 +36,15 @@ func (ep *EmbeddedPostgres) startPostgres(ctx context.Context) error {
 
 // Stop will try to stop the Postgres process gracefully returning an error when there were any problems.
 // Again, on Windows, we use pg_ctl.
-func (ep *EmbeddedPostgres) Stop() error {
-	if !ep.started {
-		return errors.New("server has not been started")
+func (pp *postgresProcess) Stop() error {
+
+	pgCtlBinary := filepath.Join(pp.Config.binariesPath, "bin/pg_ctl")
+	cmd := exec.Command(pgCtlBinary, "stop", "-w", "-D", pp.Config.dataPath)
+	cmd.Stdout = pp.Logger.file
+	cmd.Stderr = pp.Logger.file
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("could not stop postgres using %s", cmd.String())
 	}
-
-	pgCtlBinary := filepath.Join(ep.config.binariesPath, "bin/pg_ctl")
-	ep.cmd = exec.Command(pgCtlBinary, "stop", "-w", "-D", ep.config.dataPath)
-	ep.cmd.Stdout = ep.syncedLogger.file
-	ep.cmd.Stderr = ep.syncedLogger.file
-
-	if err := ep.cmd.Run(); err != nil {
-		return fmt.Errorf("could not stop postgres using %s", ep.cmd.String())
-	}
-
-	ep.started = false
-
-	if err := ep.syncedLogger.flush(); err != nil {
-		return err
-	}
-
 	return nil
 }

--- a/process_windows.go
+++ b/process_windows.go
@@ -17,9 +17,9 @@ import (
 // So for now we just use pg_ctl on Windows since it does the hoop jumping.
 func (ep *EmbeddedPostgres) startPostgres(ctx context.Context) error {
 	pgCtlBinary := filepath.Join(ep.config.binariesPath, "bin/pg_ctl")
-	ep.cmd = exec.Command(pgCtlBinary, "start",
+	ep.cmd = exec.Command(pgCtlBinary, "start", "-w",
 		"-D", ep.config.dataPath,
-		"-p", fmt.Sprintf("%d", ep.config.port))
+		"-o", fmt.Sprintf("-p %d", ep.config.port))
 	ep.cmd.Stdout = ep.syncedLogger.file
 	ep.cmd.Stderr = ep.syncedLogger.file
 
@@ -38,7 +38,7 @@ func (ep *EmbeddedPostgres) Stop() error {
 	}
 
 	pgCtlBinary := filepath.Join(ep.config.binariesPath, "bin/pg_ctl")
-	ep.cmd = exec.Command(pgCtlBinary, "stop", "-D", ep.config.dataPath)
+	ep.cmd = exec.Command(pgCtlBinary, "stop", "-w", "-D", ep.config.dataPath)
 	ep.cmd.Stdout = ep.syncedLogger.file
 	ep.cmd.Stderr = ep.syncedLogger.file
 

--- a/process_windows.go
+++ b/process_windows.go
@@ -1,0 +1,50 @@
+//go:build windows
+// +build windows
+
+package embeddedpostgres
+
+import "path/filepath"
+
+// startPostgres
+// On Windows, you need to jump through hoops to start the process as a restricted user.
+// Postgres won't start as administrator.
+// So for now we just use pg_ctl on Windows since it does the hoop jumping.
+func (ep *EmbeddedPostgres) startPostgres(ctx context.Context) error {
+	pgCtlBinary := filepath.Join(ep.config.binariesPath, "bin/pg_ctl")
+	ep.cmd = exec.Command(pgCtlBinary, "start",
+		"-D", ep.config.dataPath,
+		"-p", fmt.Sprintf("%d", ep.config.port))
+	ep.cmd.Stdout = ep.syncedLogger.file
+	ep.cmd.Stderr = ep.syncedLogger.file
+
+	if err := ep.cmd.Run(); err != nil {
+		return fmt.Errorf("could not start postgres using %s", ep.cmd.String())
+	}
+
+	return nil
+}
+
+// Stop will try to stop the Postgres process gracefully returning an error when there were any problems.
+// Again, on Windows, we use pg_ctl.
+func (ep *EmbeddedPostgres) Stop() error {
+	if !ep.started {
+		return errors.New("server has not been started")
+	}
+
+	pgCtlBinary := filepath.Join(ep.config.binariesPath, "bin/pg_ctl")
+	ep.cmd = exec.Command(pgCtlBinary, "stop", "-D", ep.config.dataPath)
+	ep.cmd.Stdout = ep.syncedLogger.file
+	ep.cmd.Stderr = ep.syncedLogger.file
+
+	if err := ep.cmd.Run(); err != nil {
+		return fmt.Errorf("could not stop postgres using %s", ep.cmd.String())
+	}
+
+	ep.started = false
+
+	if err := ep.syncedLogger.flush(); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Currently pg_ctl is used to start postgres, and we're seeing an issue where if code using this lib gets hard killed, the postgres process lives on. 
By running `postgres` directly it will die when the supervisor process dies.

Maybe there's a way to do this using pg_ctl? That would be great since then we wouldn't have to poll the port to check if the server is listening.