### PR TITLE
Allow M1 macs to use ARM-native binaries for postgres v14.2+ 

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
+	embeddedpostgres "github.com/tovala/embedded-postgres"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/fergusstrange/embedded-postgres
+module github.com/tovala/embedded-postgres
 
 go 1.13
 

--- a/version_strategy.go
+++ b/version_strategy.go
@@ -1,6 +1,7 @@
 package embeddedpostgres
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -36,9 +37,16 @@ func defaultVersionStrategy(config Config, goos, arch string, linuxMachineName f
 			}
 		}
 
-		// at this point, postgres is not available for macos on arm
+		// postgres below version 14.2 is not available for macos on arm
 		if goos == "darwin" && arch == "arm64" {
-			arch = "amd64"
+			var majorVer, minorVer int
+			fmt.Sscanf(string(config.version), "%d.%d", &majorVer, &minorVer)
+
+			if majorVer < 14 || (majorVer == 14 && minorVer < 2) {
+				arch = "amd64"
+			} else {
+				arch += "v8"
+			}
 		}
 
 		return goos, arch, config.version


### PR DESCRIPTION
Since arm64 binaries exist for postgres >= 14.2, use those. This helps avoid some architecture-specific issues when using AMD architecture binaries on ARM platforms.

See https://github.com/fergusstrange/embedded-postgres/issues/86