### PR TITLE
Upgrade versions and add support for MacOS ARM

### DIFF
--- a/config.go
+++ b/config.go
@@ -123,10 +123,11 @@ type PostgresVersion string
 
 // Predefined supported Postgres versions.
 const (
-	V14 = PostgresVersion("14.5.0")
-	V13 = PostgresVersion("13.8.0")
-	V12 = PostgresVersion("12.12.0")
-	V11 = PostgresVersion("11.17.0")
-	V10 = PostgresVersion("10.22.0")
+	V15 = PostgresVersion("15.1.0")
+	V14 = PostgresVersion("14.6.0")
+	V13 = PostgresVersion("13.9.0")
+	V12 = PostgresVersion("12.13.0")
+	V11 = PostgresVersion("11.18.0")
+	V10 = PostgresVersion("10.23.0")
 	V9  = PostgresVersion("9.6.24")
 )

--- a/embedded_postgres_test.go
+++ b/embedded_postgres_test.go
@@ -251,7 +251,7 @@ func Test_CustomConfig(t *testing.T) {
 		Username("gin").
 		Password("wine").
 		Database("beer").
-		Version(V12).
+		Version(V15).
 		RuntimePath(tempDir).
 		Port(9876).
 		StartTimeout(10 * time.Second).
@@ -496,7 +496,7 @@ func Test_CustomBinariesRepo(t *testing.T) {
 		Username("gin").
 		Password("wine").
 		Database("beer").
-		Version(V12).
+		Version(V15).
 		RuntimePath(tempDir).
 		BinaryRepositoryURL("https://repo.maven.apache.org/maven2").
 		Port(9876).

--- a/version_strategy.go
+++ b/version_strategy.go
@@ -42,6 +42,7 @@ func defaultVersionStrategy(config Config, goos, arch string, linuxMachineName f
 			var majorVer, minorVer int
 
 			fmt.Sscanf(string(config.version), "%d.%d", &majorVer, &minorVer)
+
 			if majorVer >= 15 || (majorVer == 14 && minorVer >= 2) {
 				arch += "v8"
 			} else {

--- a/version_strategy.go
+++ b/version_strategy.go
@@ -1,6 +1,7 @@
 package embeddedpostgres
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -36,9 +37,16 @@ func defaultVersionStrategy(config Config, goos, arch string, linuxMachineName f
 			}
 		}
 
-		// at this point, postgres is not available for macos on arm
+		// if available, use postgres for macos on arm
 		if goos == "darwin" && arch == "arm64" {
-			arch = "amd64"
+			var majorVer, minorVer int
+			fmt.Sscanf(string(config.version), "%d.%d", &majorVer, &minorVer)
+
+			if majorVer >= 15 || (majorVer == 14 && minorVer >= 2) {
+				arch += "v8"
+			} else {
+				arch = "amd64"
+			}
 		}
 
 		return goos, arch, config.version

--- a/version_strategy.go
+++ b/version_strategy.go
@@ -40,8 +40,8 @@ func defaultVersionStrategy(config Config, goos, arch string, linuxMachineName f
 		// if available, use postgres for macos on arm
 		if goos == "darwin" && arch == "arm64" {
 			var majorVer, minorVer int
-			fmt.Sscanf(string(config.version), "%d.%d", &majorVer, &minorVer)
 
+			fmt.Sscanf(string(config.version), "%d.%d", &majorVer, &minorVer)
 			if majorVer >= 15 || (majorVer == 14 && minorVer >= 2) {
 				arch += "v8"
 			} else {

--- a/version_strategy_test.go
+++ b/version_strategy_test.go
@@ -17,7 +17,7 @@ func Test_DefaultVersionStrategy_AllGolangDistributions(t *testing.T) {
 		"android/arm":     {"android", "arm"},
 		"android/arm64":   {"android", "arm64"},
 		"darwin/amd64":    {"darwin", "amd64"},
-		"darwin/arm64":    {"darwin", "amd64"},
+		"darwin/arm64":    {"darwin", "arm64v8"},
 		"dragonfly/amd64": {"dragonfly", "amd64"},
 		"freebsd/386":     {"freebsd", "386"},
 		"freebsd/amd64":   {"freebsd", "amd64"},


### PR DESCRIPTION
## Upgrade versions and add support for MacOS ARM

This change upgrades the versions to the latest and adds support for MacOS ARM binaries.

Changes:
* Updated versions to include V15
* Updated Test_CustomConfig to use V15 instead of V12
* Updated Test_CustomBinariesRepo to use V15 instead of V12

Verified all unit tests pass on M1 Mac Pro