### PR TITLE
Add support for MacOS ARM, upgrade versions and update unit tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,3 +48,8 @@ issues:
     - G104
     - (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)
     - Potential file inclusion via variable
+  exclude-rules:
+    - path: '(.+)_test\.go'
+      linters:
+        - funlen
+        - goconst

--- a/config.go
+++ b/config.go
@@ -123,10 +123,11 @@ type PostgresVersion string
 
 // Predefined supported Postgres versions.
 const (
-	V14 = PostgresVersion("14.5.0")
-	V13 = PostgresVersion("13.8.0")
-	V12 = PostgresVersion("12.12.0")
-	V11 = PostgresVersion("11.17.0")
-	V10 = PostgresVersion("10.22.0")
+	V15 = PostgresVersion("15.1.0")
+	V14 = PostgresVersion("14.6.0")
+	V13 = PostgresVersion("13.9.0")
+	V12 = PostgresVersion("12.13.0")
+	V11 = PostgresVersion("11.18.0")
+	V10 = PostgresVersion("10.23.0")
 	V9  = PostgresVersion("9.6.24")
 )

--- a/embedded_postgres_test.go
+++ b/embedded_postgres_test.go
@@ -251,7 +251,7 @@ func Test_CustomConfig(t *testing.T) {
 		Username("gin").
 		Password("wine").
 		Database("beer").
-		Version(V12).
+		Version(V15).
 		RuntimePath(tempDir).
 		Port(9876).
 		StartTimeout(10 * time.Second).
@@ -496,7 +496,7 @@ func Test_CustomBinariesRepo(t *testing.T) {
 		Username("gin").
 		Password("wine").
 		Database("beer").
-		Version(V12).
+		Version(V15).
 		RuntimePath(tempDir).
 		BinaryRepositoryURL("https://repo.maven.apache.org/maven2").
 		Port(9876).


### PR DESCRIPTION
## Add support for Apple ARM
* Use Mac OS ARM binaries for versions >= 14.2
* Upgrade versions and add version 15
* Update unit tests