### PR TITLE
In PostgreSQL 10 and later, the version is always a single number

### DIFF
--- a/embedded_postgres.go
+++ b/embedded_postgres.go
@@ -233,6 +233,7 @@ func dataDirIsValid(dataDir string, version PostgresVersion) bool {
 	}
 
 	v := strings.TrimSuffix(string(d), "\n")
-
+	// In PostgreSQL 10 and later, the version is always a single number:
+	v = strings.Split(v, ".")[0]
 	return strings.HasPrefix(string(version), v)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/fergusstrange/embedded-postgres
+module github.com/dgallion1/embedded-postgres
 
 go 1.18
 


### PR DESCRIPTION
Added v = strings.Split(v, ".")[0] to pick off just the first number

I wasn't sure how to handle the go.mod file.
