### PR TITLE
[config.go] Add `GetConnectionURL`

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package embeddedpostgres
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"time"
@@ -116,6 +117,10 @@ func (c Config) Logger(logger io.Writer) Config {
 func (c Config) BinaryRepositoryURL(binaryRepositoryURL string) Config {
 	c.binaryRepositoryURL = binaryRepositoryURL
 	return c
+}
+
+func (c Config) GetConnectionURL() string {
+	return fmt.Sprintf("postgresql://%s:%s@%s:%d/%s", c.username, c.password, "localhost", c.port, c.database)
 }
 
 // PostgresVersion represents the semantic version used to fetch and run the Postgres process.

--- a/test_config.go
+++ b/test_config.go
@@ -1,0 +1,12 @@
+package embeddedpostgres
+
+import "testing"
+
+func TestGetConnectionURL(t *testing.T) {
+	config := DefaultConfig().Database("mydb").Username("myuser").Password("mypass")
+	expect := "postgresql://myuser:mypass@localhost:5432/mydb"
+
+	if got := config.GetConnectionURL(); got != expect {
+		t.Errorf("expected \"%s\" got \"%s\"", expect, got)
+	}
+}


### PR DESCRIPTION
I'm assuming something like this; although maybe it'd be better to listen on a socket / named-pipe rather than use all this port and localhost stuff? - Anyway it's a start…