### PR TITLE
Support running binaries on non-standard systems

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,12 +2,16 @@ package main
 
 import (
 	"log"
+    "os"
 
 	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
 )
 
 func main() {
-	embeddedPostgres := embeddedpostgres.NewDatabase()
+    config := embeddedpostgres.DefaultConfig();
+    config = config.BinariesInterpreter(os.Getenv("POSTGRES_INTERPRETER"))
+
+	embeddedPostgres := embeddedpostgres.NewDatabase(config)
 	if err := embeddedPostgres.Start(); err != nil {
 		log.Fatal(err)
 	}

--- a/config.go
+++ b/config.go
@@ -16,6 +16,8 @@ type Config struct {
 	runtimePath         string
 	dataPath            string
 	binariesPath        string
+	binariesInterpreter string
+	binariesEnv         []string
 	locale              string
 	binaryRepositoryURL string
 	startTimeout        time.Duration
@@ -91,6 +93,21 @@ func (c Config) DataPath(path string) Config {
 // If this option is left unset, the binaries will be downloaded.
 func (c Config) BinariesPath(path string) Config {
 	c.binariesPath = path
+	return c
+}
+
+// BinariesPath sets the interpreter of the pre-downloaded postgres binaries using patchelf.
+// If this option is set, patchelf must be in the PATH
+// If this option is left unset the binaries are not patched.
+func (c Config) BinariesInterpreter(path string) Config {
+	c.binariesInterpreter = path
+	return c
+}
+
+// BinariesEnv adds/overrides environment variables in the binaries exec environments
+// If this option is left unset the binaries environment variables are unchanged.
+func (c Config) BinariesEnv(env []string) Config {
+	c.binariesEnv = env
 	return c
 }
 

--- a/embedded_postgres.go
+++ b/embedded_postgres.go
@@ -103,6 +103,10 @@ func (ep *EmbeddedPostgres) Start() error {
 		if err := decompressTarXz(defaultTarReader, cacheLocation, ep.config.binariesPath); err != nil {
 			return err
 		}
+
+		if err := patchBinaries(ep.config.binariesPath, ep.config.binariesInterpreter); err != nil {
+			return err
+		}
 	}
 
 	if err := os.MkdirAll(ep.config.runtimePath, 0755); err != nil {
@@ -153,7 +157,7 @@ func (ep *EmbeddedPostgres) cleanDataDirectoryAndInit() error {
 		return fmt.Errorf("unable to clean up data directory %s with error: %s", ep.config.dataPath, err)
 	}
 
-	if err := ep.initDatabase(ep.config.binariesPath, ep.config.runtimePath, ep.config.dataPath, ep.config.username, ep.config.password, ep.config.locale, ep.syncedLogger.file); err != nil {
+	if err := ep.initDatabase(ep.config.binariesPath, ep.config.runtimePath, ep.config.dataPath, ep.config.username, ep.config.password, ep.config.locale, ep.syncedLogger.file, ep.config.binariesEnv); err != nil {
 		return err
 	}
 

--- a/embedded_postgres_test.go
+++ b/embedded_postgres_test.go
@@ -20,7 +20,7 @@ import (
 func Test_DefaultConfig(t *testing.T) {
 	defer verifyLeak(t)
 
-	database := NewDatabase()
+	database := NewDatabase(DefaultConfig().BinariesInterpreter(os.Getenv("POSTGRES_INTERPRETER")))
 	if err := database.Start(); err != nil {
 		shutdownDBAndFail(t, err, database)
 	}
@@ -56,6 +56,7 @@ func Test_ErrorWhenPortAlreadyTaken(t *testing.T) {
 	}()
 
 	database := NewDatabase(DefaultConfig().
+		BinariesInterpreter(os.Getenv("POSTGRES_INTERPRETER")).
 		Port(9887))
 
 	err = database.Start()
@@ -64,7 +65,7 @@ func Test_ErrorWhenPortAlreadyTaken(t *testing.T) {
 }
 
 func Test_ErrorWhenRemoteFetchError(t *testing.T) {
-	database := NewDatabase()
+	database := NewDatabase(DefaultConfig().BinariesInterpreter(os.Getenv("POSTGRES_INTERPRETER")))
 	database.cacheLocator = func() (string, bool) {
 		return "", false
 	}
@@ -82,6 +83,7 @@ func Test_ErrorWhenUnableToUnArchiveFile_WrongFormat(t *testing.T) {
 	defer cleanUp()
 
 	database := NewDatabase(DefaultConfig().
+		BinariesInterpreter(os.Getenv("POSTGRES_INTERPRETER")).
 		Username("gin").
 		Password("wine").
 		Database("beer").
@@ -112,6 +114,7 @@ func Test_ErrorWhenUnableToInitDatabase(t *testing.T) {
 	}
 
 	database := NewDatabase(DefaultConfig().
+		BinariesInterpreter(os.Getenv("POSTGRES_INTERPRETER")).
 		Username("gin").
 		Password("wine").
 		Database("beer").
@@ -122,7 +125,7 @@ func Test_ErrorWhenUnableToInitDatabase(t *testing.T) {
 		return jarFile, true
 	}
 
-	database.initDatabase = func(binaryExtractLocation, runtimePath, dataLocation, username, password, locale string, logger *os.File) error {
+	database.initDatabase = func(binaryExtractLocation, runtimePath, dataLocation, username, password, locale string, logger *os.File, env []string) error {
 		return errors.New("ah it did not work")
 	}
 
@@ -149,6 +152,7 @@ func Test_ErrorWhenUnableToCreateDatabase(t *testing.T) {
 	}
 
 	database := NewDatabase(DefaultConfig().
+		BinariesInterpreter(os.Getenv("POSTGRES_INTERPRETER")).
 		Username("gin").
 		Password("wine").
 		Database("beer").
@@ -172,6 +176,7 @@ func Test_ErrorWhenUnableToCreateDatabase(t *testing.T) {
 
 func Test_TimesOutWhenCannotStart(t *testing.T) {
 	database := NewDatabase(DefaultConfig().
+		BinariesInterpreter(os.Getenv("POSTGRES_INTERPRETER")).
 		Database("something-fancy").
 		StartTimeout(500 * time.Millisecond))
 
@@ -185,7 +190,7 @@ func Test_TimesOutWhenCannotStart(t *testing.T) {
 }
 
 func Test_ErrorWhenStopCalledBeforeStart(t *testing.T) {
-	database := NewDatabase()
+	database := NewDatabase(DefaultConfig().BinariesInterpreter(os.Getenv("POSTGRES_INTERPRETER")))
 
 	err := database.Stop()
 
@@ -193,7 +198,7 @@ func Test_ErrorWhenStopCalledBeforeStart(t *testing.T) {
 }
 
 func Test_ErrorWhenStartCalledWhenAlreadyStarted(t *testing.T) {
-	database := NewDatabase()
+	database := NewDatabase(DefaultConfig().BinariesInterpreter(os.Getenv("POSTGRES_INTERPRETER")))
 
 	defer func() {
 		if err := database.Stop(); err != nil {
@@ -219,13 +224,14 @@ func Test_ErrorWhenCannotStartPostgresProcess(t *testing.T) {
 	}
 
 	database := NewDatabase(DefaultConfig().
+		BinariesInterpreter(os.Getenv("POSTGRES_INTERPRETER")).
 		RuntimePath(extractPath))
 
 	database.cacheLocator = func() (string, bool) {
 		return jarFile, true
 	}
 
-	database.initDatabase = func(binaryExtractLocation, runtimePath, dataLocation, username, password, locale string, logger *os.File) error {
+	database.initDatabase = func(binaryExtractLocation, runtimePath, dataLocation, username, password, locale string, logger *os.File, env []string) error {
 		_, _ = logger.Write([]byte("ah it did not work"))
 		return nil
 	}
@@ -248,6 +254,7 @@ func Test_CustomConfig(t *testing.T) {
 	}()
 
 	database := NewDatabase(DefaultConfig().
+		BinariesInterpreter(os.Getenv("POSTGRES_INTERPRETER")).
 		Username("gin").
 		Password("wine").
 		Database("beer").
@@ -295,6 +302,7 @@ func Test_CustomLog(t *testing.T) {
 	logger := customLogger{}
 
 	database := NewDatabase(DefaultConfig().
+		BinariesInterpreter(os.Getenv("POSTGRES_INTERPRETER")).
 		Logger(&logger))
 
 	if err := database.Start(); err != nil {
@@ -332,7 +340,7 @@ func Test_CustomLog(t *testing.T) {
 
 func Test_CustomLocaleConfig(t *testing.T) {
 	// C is the only locale we can guarantee to always work
-	database := NewDatabase(DefaultConfig().Locale("C"))
+	database := NewDatabase(DefaultConfig().Locale("C").BinariesInterpreter(os.Getenv("POSTGRES_INTERPRETER")))
 	if err := database.Start(); err != nil {
 		shutdownDBAndFail(t, err, database)
 	}
@@ -356,7 +364,7 @@ func Test_CustomLocaleConfig(t *testing.T) {
 }
 
 func Test_CanStartAndStopTwice(t *testing.T) {
-	database := NewDatabase()
+	database := NewDatabase(DefaultConfig().BinariesInterpreter(os.Getenv("POSTGRES_INTERPRETER")))
 
 	if err := database.Start(); err != nil {
 		shutdownDBAndFail(t, err, database)
@@ -413,7 +421,7 @@ func Test_ReuseData(t *testing.T) {
 		}
 	}()
 
-	database := NewDatabase(DefaultConfig().DataPath(tempDir))
+	database := NewDatabase(DefaultConfig().DataPath(tempDir).BinariesInterpreter(os.Getenv("POSTGRES_INTERPRETER")))
 
 	if err := database.Start(); err != nil {
 		shutdownDBAndFail(t, err, database)
@@ -440,7 +448,7 @@ func Test_ReuseData(t *testing.T) {
 		shutdownDBAndFail(t, err, database)
 	}
 
-	database = NewDatabase(DefaultConfig().DataPath(tempDir))
+	database = NewDatabase(DefaultConfig().DataPath(tempDir).BinariesInterpreter(os.Getenv("POSTGRES_INTERPRETER")))
 
 	if err := database.Start(); err != nil {
 		shutdownDBAndFail(t, err, database)
@@ -498,6 +506,7 @@ func Test_CustomBinariesRepo(t *testing.T) {
 		Version(V15).
 		RuntimePath(tempDir).
 		BinaryRepositoryURL("https://repo.maven.apache.org/maven2").
+		BinariesInterpreter(os.Getenv("POSTGRES_INTERPRETER")).
 		Port(9876).
 		StartTimeout(10 * time.Second).
 		Locale("C").
@@ -538,6 +547,7 @@ func Test_CustomBinariesLocation(t *testing.T) {
 	}()
 
 	database := NewDatabase(DefaultConfig().
+		BinariesInterpreter(os.Getenv("POSTGRES_INTERPRETER")).
 		BinariesPath(tempDir))
 
 	if err := database.Start(); err != nil {
@@ -598,6 +608,10 @@ func Test_PrefetchedBinaries(t *testing.T) {
 		panic(err)
 	}
 
+	if err := patchBinaries(binTempDir, os.Getenv("POSTGRES_INTERPRETER")); err != nil {
+		panic(err)
+	}
+
 	// Expect everything to work without cacheLocator and/or remoteFetch abilities.
 	database.cacheLocator = func() (string, bool) {
 		return "", false
@@ -627,7 +641,7 @@ func Test_RunningInParallel(t *testing.T) {
 	runTestWithPortAndPath := func(port uint32, path string) {
 		defer waitGroup.Done()
 
-		database := NewDatabase(DefaultConfig().Port(port).RuntimePath(path))
+		database := NewDatabase(DefaultConfig().Port(port).RuntimePath(path).BinariesInterpreter(os.Getenv("POSTGRES_INTERPRETER")))
 		if err := database.Start(); err != nil {
 			shutdownDBAndFail(t, err, database)
 		}

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
+    "os"
 
 	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
 	"github.com/jmoiron/sqlx"
@@ -15,8 +16,12 @@ import (
 	"go.uber.org/zap/zapio"
 )
 
+func MakeConfig() embeddedpostgres.Config {
+    return embeddedpostgres.DefaultConfig().BinariesInterpreter(os.Getenv("POSTGRES_INTERPRETER"))
+}
+
 func Test_GooseMigrations(t *testing.T) {
-	database := embeddedpostgres.NewDatabase()
+	database := embeddedpostgres.NewDatabase(MakeConfig())
 	if err := database.Start(); err != nil {
 		t.Fatal(err)
 	}
@@ -45,7 +50,7 @@ func Test_ZapioLogger(t *testing.T) {
 
 	w := &zapio.Writer{Log: logger}
 
-	database := embeddedpostgres.NewDatabase(embeddedpostgres.DefaultConfig().
+	database := embeddedpostgres.NewDatabase(MakeConfig().
 		Logger(w))
 	if err := database.Start(); err != nil {
 		t.Fatal(err)
@@ -68,7 +73,7 @@ func Test_ZapioLogger(t *testing.T) {
 }
 
 func Test_Sqlx_SelectOne(t *testing.T) {
-	database := embeddedpostgres.NewDatabase()
+	database := embeddedpostgres.NewDatabase(MakeConfig())
 	if err := database.Start(); err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +102,7 @@ func Test_Sqlx_SelectOne(t *testing.T) {
 }
 
 func Test_ManyTestsAgainstOneDatabase(t *testing.T) {
-	database := embeddedpostgres.NewDatabase()
+	database := embeddedpostgres.NewDatabase(MakeConfig())
 	if err := database.Start(); err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +165,7 @@ func Test_ManyTestsAgainstOneDatabase(t *testing.T) {
 }
 
 func Test_SimpleHttpWebApp(t *testing.T) {
-	database := embeddedpostgres.NewDatabase()
+	database := embeddedpostgres.NewDatabase(MakeConfig())
 	if err := database.Start(); err != nil {
 		t.Fatal(err)
 	}

--- a/patch_binaries.go
+++ b/patch_binaries.go
@@ -1,0 +1,28 @@
+package embeddedpostgres
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func patchBinaries(extractPath string, interpreterPath string) error {
+	if interpreterPath == "" {
+		return nil
+	}
+
+	binaries := [3]string{"pg_ctl", "initdb", "postgres"}
+	for _, binary := range binaries {
+		path := filepath.Join(extractPath, "bin", binary)
+		_, fileErr := os.Stat(path)
+		if os.IsNotExist(fileErr) {
+			continue
+		}
+		if err := exec.Command("patchelf", "--set-interpreter", interpreterPath, path).Run(); err != nil {
+			return fmt.Errorf("unable to patch %s: %s", binary, err)
+		}
+	}
+
+	return nil
+}

--- a/platform-test/platform_test.go
+++ b/platform-test/platform_test.go
@@ -35,6 +35,7 @@ func Test_AllMajorVersions(t *testing.T) {
 			runtimePath := filepath.Join(tempExtractLocation, string(version))
 
 			database := embeddedpostgres.NewDatabase(embeddedpostgres.DefaultConfig().
+                BinariesInterpreter(os.Getenv("POSTGRES_INTERPRETER")).
 				Version(version).
 				Port(port).
 				RuntimePath(runtimePath))

--- a/prepare_database.go
+++ b/prepare_database.go
@@ -18,10 +18,10 @@ const (
 	fmtAfterError  = "%v happened after error: %w"
 )
 
-type initDatabase func(binaryExtractLocation, runtimePath, pgDataDir, username, password, locale string, logger *os.File) error
+type initDatabase func(binaryExtractLocation, runtimePath, pgDataDir, username, password, locale string, logger *os.File, env []string) error
 type createDatabase func(port uint32, username, password, database string) error
 
-func defaultInitDatabase(binaryExtractLocation, runtimePath, pgDataDir, username, password, locale string, logger *os.File) error {
+func defaultInitDatabase(binaryExtractLocation, runtimePath, pgDataDir, username, password, locale string, logger *os.File, env []string) error {
 	passwordFile, err := createPasswordFile(runtimePath, password)
 	if err != nil {
 		return err
@@ -42,6 +42,9 @@ func defaultInitDatabase(binaryExtractLocation, runtimePath, pgDataDir, username
 	postgresInitDBProcess := exec.Command(postgresInitDBBinary, args...)
 	postgresInitDBProcess.Stderr = logger
 	postgresInitDBProcess.Stdout = logger
+	if env != nil {
+		postgresInitDBProcess.Env = append(os.Environ(), env...)
+	}
 
 	if err = postgresInitDBProcess.Run(); err != nil {
 		logContent, readLogsErr := readLogsOrTimeout(logger) // we want to preserve the original error

--- a/prepare_database_test.go
+++ b/prepare_database_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func Test_defaultInitDatabase_ErrorWhenCannotCreatePasswordFile(t *testing.T) {
-	err := defaultInitDatabase("path_not_exists", "path_not_exists", "path_not_exists", "Tom", "Beer", "", os.Stderr)
+	err := defaultInitDatabase("path_not_exists", "path_not_exists", "path_not_exists", "Tom", "Beer", "", os.Stderr, nil)
 
 	assert.EqualError(t, err, "unable to write password file to path_not_exists/pwfile")
 }
@@ -49,7 +49,7 @@ func Test_defaultInitDatabase_ErrorWhenCannotStartInitDBProcess(t *testing.T) {
 
 	_, _ = logFile.Write([]byte("and here are the logs!"))
 
-	err = defaultInitDatabase(binTempDir, runtimeTempDir, filepath.Join(runtimeTempDir, "data"), "Tom", "Beer", "", logFile)
+	err = defaultInitDatabase(binTempDir, runtimeTempDir, filepath.Join(runtimeTempDir, "data"), "Tom", "Beer", "", logFile, nil)
 
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("unable to init database using '%s/bin/initdb -A password -U Tom -D %s/data --pwfile=%s/pwfile'",
@@ -72,7 +72,7 @@ func Test_defaultInitDatabase_ErrorInvalidLocaleSetting(t *testing.T) {
 		}
 	}()
 
-	err = defaultInitDatabase(tempDir, tempDir, filepath.Join(tempDir, "data"), "postgres", "postgres", "en_XY", os.Stderr)
+	err = defaultInitDatabase(tempDir, tempDir, filepath.Join(tempDir, "data"), "postgres", "postgres", "en_XY", os.Stderr, nil)
 
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("unable to init database using '%s/bin/initdb -A password -U postgres -D %s/data --pwfile=%s/pwfile --locale=en_XY'",
@@ -93,7 +93,7 @@ func Test_defaultInitDatabase_PwFileRemoved(t *testing.T) {
 		}
 	}()
 
-	database := NewDatabase(DefaultConfig().RuntimePath(tempDir))
+	database := NewDatabase(DefaultConfig().RuntimePath(tempDir).BinariesInterpreter(os.Getenv("POSTGRES_INTERPRETER")))
 	if err := database.Start(); err != nil {
 		t.Fatal(err)
 	}
@@ -118,6 +118,7 @@ func Test_defaultCreateDatabase_ErrorWhenSQLOpenError(t *testing.T) {
 
 func Test_defaultCreateDatabase_ErrorWhenQueryError(t *testing.T) {
 	database := NewDatabase(DefaultConfig().
+		BinariesInterpreter(os.Getenv("POSTGRES_INTERPRETER")).
 		Port(9831).
 		Database("b33r"))
 	if err := database.Start(); err != nil {


### PR DESCRIPTION
On some systems (eg NixOS), libraries and the interpreter path need to be patched. Thus, add two config options to support this.

1. Config option for setting the binary interpreter using patchelf. Occurs on first download
2. Config option for adding/overriding the binaries exec environment variables. Eg. for `LD_LIBRARY_PATH`. The `initDatabase` type now takes an extra parameter `env`.

These by default are unset and do not change existing behavior. The tests have been updated to take in `POSTGRES_INTERPRETER` for setting the interpreter.

I was able to successfully run the test suite on NixOS with these changes. To avoid changing the test suite further, I just used `LD_LIBRARY_PATH` as a global env variable. I am not sure the best way to test this otherwise as I cannot commit to keeping a Nix CI up to date.