### PR TITLE
Rename directories on Windows does not need syscall.Fsync() on rename.

### DIFF
--- a/config.go
+++ b/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	dataPath            string
 	binariesPath        string
 	locale              string
+	useUnixSocket       string
 	binaryRepositoryURL string
 	startTimeout        time.Duration
 	logger              io.Writer
@@ -38,6 +39,7 @@ func DefaultConfig() Config {
 		username:            "postgres",
 		password:            "postgres",
 		startTimeout:        15 * time.Second,
+		useUnixSocket:       "",
 		logger:              os.Stdout,
 		binaryRepositoryURL: "https://repo1.maven.org/maven2",
 	}
@@ -97,6 +99,12 @@ func (c Config) BinariesPath(path string) Config {
 // Locale sets the default locale for initdb
 func (c Config) Locale(locale string) Config {
 	c.locale = locale
+	return c
+}
+
+// Use the specified unix socket directory instead of a TCP socket.
+func (c Config) UseUnixSocket(useUnixSocket string) Config {
+	c.useUnixSocket = useUnixSocket
 	return c
 }
 

--- a/embedded_postgres.go
+++ b/embedded_postgres.go
@@ -1,6 +1,7 @@
 package embeddedpostgres
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -9,7 +10,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
+	"time"
 )
 
 // EmbeddedPostgres maintains all configuration and runtime functions for maintaining the lifecycle of one Postgres process.
@@ -190,18 +193,80 @@ func (ep *EmbeddedPostgres) Stop() error {
 }
 
 func startPostgres(ep *EmbeddedPostgres) error {
-	postgresBinary := filepath.Join(ep.config.binariesPath, "bin/pg_ctl")
-	postgresProcess := exec.Command(postgresBinary, "start", "-w",
+	// We don't use pg_ctl since that starts postgres in the background. We want
+	// postgres to die if this process dies.
+
+	postgresBinary := filepath.Join(ep.config.binariesPath, "bin/postgres")
+	postgresProcess := exec.Command(postgresBinary,
 		"-D", ep.config.dataPath,
-		"-o", fmt.Sprintf(`"-p %d"`, ep.config.port))
+		"-p", strconv.Itoa(int(ep.config.port)))
 	postgresProcess.Stdout = ep.syncedLogger.file
 	postgresProcess.Stderr = ep.syncedLogger.file
 
-	if err := postgresProcess.Run(); err != nil {
-		return fmt.Errorf("could not start postgres using %s", postgresProcess.String())
+	// We open stdin so that when this process dies postgres will get a signal.
+	stdin, err := postgresProcess.StdinPipe()
+	if err != nil {
+		return err
 	}
 
-	return nil
+	if err := postgresProcess.Start(); err != nil {
+		return fmt.Errorf("could not start postgres using %s: %w", postgresProcess.String(), err)
+	}
+
+	waitErrC := make(chan error, 1)
+	go func() {
+		defer stdin.Close()
+		err := postgresProcess.Wait()
+		waitErrC <- err
+		if err != nil {
+			_, _ = fmt.Fprintf(ep.syncedLogger.file, "%v embedded-postgres process exited with non-zero exit code: %v\n", time.Now(), err)
+		}
+	}()
+
+	// Wait for pg_ctl to report happy news
+	defaultWait := 60 * time.Second // mirrors pg_ctl's DEFAULT_WAIT
+	deadline := time.Now().Add(defaultWait)
+	for time.Now().Before(deadline) {
+		if isReadyPostgres(ep) {
+			// Success
+			return nil
+		}
+
+		select {
+		case err := <-waitErrC:
+			return fmt.Errorf("could not start postgres using %s: %w", postgresProcess.String(), err)
+		case <-time.After(time.Second / 10): // mirrors pg_ctl's WAITS_PER_SEC
+			// try again
+		}
+	}
+
+	// Failed to start, best-effort kill process and return an error
+	_ = stdin.Close()
+	_ = postgresProcess.Process.Kill()
+	return fmt.Errorf("postgres failed to start after %v using %s", defaultWait, postgresProcess.String())
+}
+
+func isReadyPostgres(ep *EmbeddedPostgres) bool {
+	pgCtl := filepath.Join(ep.config.binariesPath, "bin/pg_ctl")
+	if exec.Command(pgCtl, "-D", ep.config.dataPath, "status").Run() != nil {
+		return false
+	}
+
+	// pg_ctl status returning success isn't enough, it just checks if the
+	// postmaster PID is running. To be equivalent to pg_ctl start we also need
+	// to check the status of the postmaster is ready. Without this check
+	// queries will fail at first.
+	//
+	// The format of this PID file has been stable since Postgres 10.
+	// https://sourcegraph.com/github.com/postgres/postgres@REL_15_2/-/blob/src/include/utils/pidfile.h?L44
+	linePMStatus := 8
+	pmStatusReady := "ready   "
+	b, err := os.ReadFile(filepath.Join(ep.config.dataPath, "postmaster.pid"))
+	if err != nil {
+		return false
+	}
+	lines := bytes.Split(b, []byte("\n")) // pg_ctl readline only considers \n for newline (never \r\n)
+	return len(lines) >= linePMStatus && bytes.Equal(lines[linePMStatus-1], []byte(pmStatusReady))
 }
 
 func stopPostgres(ep *EmbeddedPostgres) error {

--- a/embedded_postgres_test.go
+++ b/embedded_postgres_test.go
@@ -123,7 +123,7 @@ func Test_ErrorWhenUnableToInitDatabase(t *testing.T) {
 		return jarFile, true
 	}
 
-	database.initDatabase = func(binaryExtractLocation, runtimePath, dataLocation, username, password, locale string, logger *os.File) error {
+	database.initDatabase = func(binaryExtractLocation, runtimePath, dataLocation, username, password, locale string, useUnixSocket string, logger *os.File) error {
 		return errors.New("ah it did not work")
 	}
 
@@ -156,7 +156,7 @@ func Test_ErrorWhenUnableToCreateDatabase(t *testing.T) {
 		RuntimePath(extractPath).
 		StartTimeout(10 * time.Second))
 
-	database.createDatabase = func(port uint32, username, password, database string) error {
+	database.createDatabase = func(host string, port uint32, username, password, database string) error {
 		return errors.New("ah noes")
 	}
 
@@ -176,7 +176,7 @@ func Test_TimesOutWhenCannotStart(t *testing.T) {
 		Database("something-fancy").
 		StartTimeout(500 * time.Millisecond))
 
-	database.createDatabase = func(port uint32, username, password, database string) error {
+	database.createDatabase = func(host string, port uint32, username, password, database string) error {
 		return nil
 	}
 
@@ -226,7 +226,7 @@ func Test_ErrorWhenCannotStartPostgresProcess(t *testing.T) {
 		return jarFile, true
 	}
 
-	database.initDatabase = func(binaryExtractLocation, runtimePath, dataLocation, username, password, locale string, logger *os.File) error {
+	database.initDatabase = func(binaryExtractLocation, runtimePath, dataLocation, username, password, locale string, useUnixSocket string, logger *os.File) error {
 		return nil
 	}
 

--- a/embedded_postgres_test.go
+++ b/embedded_postgres_test.go
@@ -232,7 +232,7 @@ func Test_ErrorWhenCannotStartPostgresProcess(t *testing.T) {
 
 	err = database.Start()
 
-	assert.EqualError(t, err, fmt.Sprintf(`could not start postgres using %s/bin/pg_ctl start -w -D %s/data -o "-p 5432"`, extractPath, extractPath))
+	assert.Contains(t, err.Error(), fmt.Sprintf(`could not start postgres using %s/bin/postgres -D %s/data -p 5432`, extractPath, extractPath))
 }
 
 func Test_CustomConfig(t *testing.T) {

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -1,0 +1,36 @@
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// RenameAndSync will do an os.Rename followed by fsync to ensure the rename
+// is recorded
+func RenameAndSync(oldpath, newpath string) error {
+	err := os.Rename(oldpath, newpath)
+	if err != nil {
+		return err
+	}
+
+	oldparent, newparent := filepath.Dir(oldpath), filepath.Dir(newpath)
+	err = fsync(newparent)
+	if oldparent != newparent {
+		if err1 := fsync(oldparent); err == nil {
+			err = err1
+		}
+	}
+	return err
+}
+
+func fsync(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	err = f.Sync()
+	if err1 := f.Close(); err == nil {
+		err = err1
+	}
+	return err
+}

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package fileutil
 
 import (

--- a/internal/fileutil/fileutil_windows.go
+++ b/internal/fileutil/fileutil_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+// +build windows
+
+package fileutil
+
+import (
+	"os"
+)
+
+// RenameAndSync will do an os.Rename followed by fsync to ensure the rename
+// is recorded
+func RenameAndSync(oldpath, newpath string) error {
+	return os.Rename(oldpath, newpath)
+}

--- a/prepare_database_test.go
+++ b/prepare_database_test.go
@@ -41,7 +41,7 @@ func Test_defaultInitDatabase_ErrorWhenCannotStartInitDBProcess(t *testing.T) {
 	err = defaultInitDatabase(binTempDir, runtimeTempDir, filepath.Join(runtimeTempDir, "data"), "Tom", "Beer", "", "", os.Stderr)
 
 	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), fmt.Sprintf("unable to init database using '%s/bin/initdb -A password -U Tom -D %s/data --pwfile=%s/pwfile'",
+	assert.Contains(t, err.Error(), fmt.Sprintf("unable to init database using '%s/bin/initdb -A password --pwfile=%s/pwfile -U Tom -D %s/data'",
 		binTempDir,
 		runtimeTempDir,
 		runtimeTempDir))
@@ -63,7 +63,7 @@ func Test_defaultInitDatabase_ErrorInvalidLocaleSetting(t *testing.T) {
 	err = defaultInitDatabase(tempDir, tempDir, filepath.Join(tempDir, "data"), "postgres", "postgres", "en_XY", "", os.Stderr)
 
 	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), fmt.Sprintf("unable to init database using '%s/bin/initdb -A password -U postgres -D %s/data --pwfile=%s/pwfile --locale=en_XY'",
+	assert.Contains(t, err.Error(), fmt.Sprintf("unable to init database using '%s/bin/initdb -A password --pwfile=%s/pwfile -U postgres -D %s/data --locale=en_XY'",
 		tempDir,
 		tempDir,
 		tempDir))

--- a/prepare_database_test.go
+++ b/prepare_database_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func Test_defaultInitDatabase_ErrorWhenCannotCreatePasswordFile(t *testing.T) {
-	err := defaultInitDatabase("path_not_exists", "path_not_exists", "path_not_exists", "Tom", "Beer", "", os.Stderr)
+	err := defaultInitDatabase("path_not_exists", "path_not_exists", "path_not_exists", "Tom", "Beer", "", "", os.Stderr)
 
 	assert.EqualError(t, err, "unable to write password file to path_not_exists/pwfile")
 }
@@ -38,7 +38,7 @@ func Test_defaultInitDatabase_ErrorWhenCannotStartInitDBProcess(t *testing.T) {
 		}
 	}()
 
-	err = defaultInitDatabase(binTempDir, runtimeTempDir, filepath.Join(runtimeTempDir, "data"), "Tom", "Beer", "", os.Stderr)
+	err = defaultInitDatabase(binTempDir, runtimeTempDir, filepath.Join(runtimeTempDir, "data"), "Tom", "Beer", "", "", os.Stderr)
 
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("unable to init database using '%s/bin/initdb -A password -U Tom -D %s/data --pwfile=%s/pwfile'",
@@ -60,7 +60,7 @@ func Test_defaultInitDatabase_ErrorInvalidLocaleSetting(t *testing.T) {
 		}
 	}()
 
-	err = defaultInitDatabase(tempDir, tempDir, filepath.Join(tempDir, "data"), "postgres", "postgres", "en_XY", os.Stderr)
+	err = defaultInitDatabase(tempDir, tempDir, filepath.Join(tempDir, "data"), "postgres", "postgres", "en_XY", "", os.Stderr)
 
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("unable to init database using '%s/bin/initdb -A password -U postgres -D %s/data --pwfile=%s/pwfile --locale=en_XY'",
@@ -99,7 +99,7 @@ func Test_defaultInitDatabase_PwFileRemoved(t *testing.T) {
 }
 
 func Test_defaultCreateDatabase_ErrorWhenSQLOpenError(t *testing.T) {
-	err := defaultCreateDatabase(1234, "user client_encoding=lol", "password", "database")
+	err := defaultCreateDatabase("localhost", 1234, "user client_encoding=lol", "password", "database")
 
 	assert.EqualError(t, err, "unable to connect to create database with custom name database with the following error: client_encoding must be absent or 'UTF8'")
 }
@@ -118,13 +118,13 @@ func Test_defaultCreateDatabase_ErrorWhenQueryError(t *testing.T) {
 		}
 	}()
 
-	err := defaultCreateDatabase(9831, "postgres", "postgres", "b33r")
+	err := defaultCreateDatabase("localhost", 9831, "postgres", "postgres", "b33r")
 
 	assert.EqualError(t, err, `unable to connect to create database with custom name b33r with the following error: pq: database "b33r" already exists`)
 }
 
 func Test_healthCheckDatabase_ErrorWhenSQLConnectingError(t *testing.T) {
-	err := healthCheckDatabase(1234, "tom client_encoding=lol", "more", "b33r")
+	err := healthCheckDatabase("localhost", 1234, "tom client_encoding=lol", "more", "b33r")
 
 	assert.EqualError(t, err, "client_encoding must be absent or 'UTF8'")
 }


### PR DESCRIPTION
On Windows the `os.Rename` does not require a subsequent call to `syscall.Fsync()`. This change avoid `ERROR_ACCESS_DENIED` as the folder is already opened by the process that extracted the installation.