### PR TITLE
Allow creating databases with dashes in the name

### DIFF
--- a/prepare_database.go
+++ b/prepare_database.go
@@ -82,7 +82,7 @@ func defaultCreateDatabase(port uint32, username, password, database string) (er
 		err = connectionClose(db, err)
 	}()
 
-	if _, err := db.Exec(fmt.Sprintf("CREATE DATABASE %s", database)); err != nil {
+	if _, err := db.Exec(fmt.Sprintf("CREATE DATABASE \"%s\"", database)); err != nil {
 		return errorCustomDatabase(database, err)
 	}
 

--- a/prepare_database_test.go
+++ b/prepare_database_test.go
@@ -116,6 +116,20 @@ func Test_defaultCreateDatabase_ErrorWhenSQLOpenError(t *testing.T) {
 	assert.EqualError(t, err, "unable to connect to create database with custom name database with the following error: client_encoding must be absent or 'UTF8'")
 }
 
+func Test_defaultCreateDatabase_DashesInName(t *testing.T) {
+	database := NewDatabase(DefaultConfig().
+		Port(9832).
+		Database("my-cool-database"))
+
+	if err := database.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := database.Stop(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func Test_defaultCreateDatabase_ErrorWhenQueryError(t *testing.T) {
 	database := NewDatabase(DefaultConfig().
 		Port(9831).


### PR DESCRIPTION
Fixes creating databases with dashes in the name, which currently results in `unable to connect to create database with custom name my-cool-database with the following error: pq: syntax error at or near "-"`