### PR TITLE
Add V16 constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This library aims to require as little configuration as possible, favouring over
 | Username            | postgres                                        |
 | Password            | postgres                                        |
 | Database            | postgres                                        |
-| Version             | 12.1.0                                          |
+| Version             | 15.3.0                                          |
 | CachePath           | $USER_HOME/.embedded-postgres-go/               |
 | RuntimePath         | $USER_HOME/.embedded-postgres-go/extracted      |
 | DataPath            | $USER_HOME/.embedded-postgres-go/extracted/data |

--- a/config.go
+++ b/config.go
@@ -27,7 +27,7 @@ type Config struct {
 
 // DefaultConfig provides a default set of configuration to be used "as is" or modified using the provided builders.
 // The following can be assumed as defaults:
-// Version:      14
+// Version:      15
 // Port:         5432
 // Database:     postgres
 // Username:     postgres
@@ -146,6 +146,7 @@ type PostgresVersion string
 
 // Predefined supported Postgres versions.
 const (
+	V16 = PostgresVersion("16.2.0")
 	V15 = PostgresVersion("15.3.0")
 	V14 = PostgresVersion("14.8.0")
 	V13 = PostgresVersion("13.11.0")

--- a/platform-test/platform_test.go
+++ b/platform-test/platform_test.go
@@ -14,6 +14,7 @@ import (
 
 func Test_AllMajorVersions(t *testing.T) {
 	allVersions := []embeddedpostgres.PostgresVersion{
+		embeddedpostgres.V16,
 		embeddedpostgres.V15,
 		embeddedpostgres.V14,
 	}


### PR DESCRIPTION
Hi,

I'd like to use V16 and it's much nicer to have a constant.

Updated the docs w/ current default (V15).

Would also update default version to V16 if desired.