### PR TITLE
make encoding configurable in initdb

### DIFF
--- a/config.go
+++ b/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	dataPath            string
 	binariesPath        string
 	locale              string
+	encoding            string
 	startParameters     map[string]string
 	binaryRepositoryURL string
 	startTimeout        time.Duration
@@ -107,6 +108,12 @@ func (c Config) BinariesPath(path string) Config {
 // Locale sets the default locale for initdb
 func (c Config) Locale(locale string) Config {
 	c.locale = locale
+	return c
+}
+
+// Encoding sets the default character set for initdb
+func (c Config) Encoding(encoding string) Config {
+	c.encoding = encoding
 	return c
 }
 

--- a/embedded_postgres.go
+++ b/embedded_postgres.go
@@ -167,7 +167,7 @@ func (ep *EmbeddedPostgres) cleanDataDirectoryAndInit() error {
 		return fmt.Errorf("unable to clean up data directory %s with error: %s", ep.config.dataPath, err)
 	}
 
-	if err := ep.initDatabase(ep.config.binariesPath, ep.config.runtimePath, ep.config.dataPath, ep.config.username, ep.config.password, ep.config.locale, ep.syncedLogger.file); err != nil {
+	if err := ep.initDatabase(ep.config.binariesPath, ep.config.runtimePath, ep.config.dataPath, ep.config.username, ep.config.password, ep.config.locale, ep.config.encoding, ep.syncedLogger.file); err != nil {
 		return err
 	}
 

--- a/prepare_database.go
+++ b/prepare_database.go
@@ -18,10 +18,10 @@ const (
 	fmtAfterError  = "%v happened after error: %w"
 )
 
-type initDatabase func(binaryExtractLocation, runtimePath, pgDataDir, username, password, locale string, logger *os.File) error
+type initDatabase func(binaryExtractLocation, runtimePath, pgDataDir, username, password, locale string, encoding string, logger *os.File) error
 type createDatabase func(port uint32, username, password, database string) error
 
-func defaultInitDatabase(binaryExtractLocation, runtimePath, pgDataDir, username, password, locale string, logger *os.File) error {
+func defaultInitDatabase(binaryExtractLocation, runtimePath, pgDataDir, username, password, locale string, encoding string, logger *os.File) error {
 	passwordFile, err := createPasswordFile(runtimePath, password)
 	if err != nil {
 		return err
@@ -36,6 +36,10 @@ func defaultInitDatabase(binaryExtractLocation, runtimePath, pgDataDir, username
 
 	if locale != "" {
 		args = append(args, fmt.Sprintf("--locale=%s", locale))
+	}
+
+	if encoding != "" {
+		args = append(args, fmt.Sprintf("--encoding=%s", encoding))
 	}
 
 	postgresInitDBBinary := filepath.Join(binaryExtractLocation, "bin/initdb")


### PR DESCRIPTION
I'd like to be able to configure the character set/encoding on a cluster level.

Is this a feature that's wanted?

If so, I'd look into error handling and write some tests.

https://github.com/fergusstrange/embedded-postgres/issues/74