### PR TITLE
fix: error typos and introduce error types

### DIFF
--- a/embedded_postgres_test.go
+++ b/embedded_postgres_test.go
@@ -190,7 +190,7 @@ func Test_ErrorWhenStopCalledBeforeStart(t *testing.T) {
 
 	err := database.Stop()
 
-	assert.EqualError(t, err, "server has not been started")
+	assert.ErrorIs(t, err, ErrServerNotStarted)
 }
 
 func Test_ErrorWhenStartCalledWhenAlreadyStarted(t *testing.T) {
@@ -206,7 +206,7 @@ func Test_ErrorWhenStartCalledWhenAlreadyStarted(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = database.Start()
-	assert.EqualError(t, err, "server is already started")
+	assert.ErrorIs(t, err, ErrServerAlreadyStarted)
 }
 
 func Test_ErrorWhenCannotStartPostgresProcess(t *testing.T) {


### PR DESCRIPTION
Noticed some typos in some error messages and fixed those.

Additionally, one of the common things I'd like to do when cleaning up is e.g. react properly on the "server has not been started" error. While that's possible by doing error message comparison, it would be nice exporting a type for both the start and stop cases similar to e.g. the `net/http` library.