### PR TITLE
Add option for launching in own process group

### DIFF
--- a/config.go
+++ b/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	binaryRepositoryURL string
 	startTimeout        time.Duration
 	logger              io.Writer
+	ownProcessGroup     bool
 }
 
 // DefaultConfig provides a default set of configuration to be used "as is" or modified using the provided builders.
@@ -141,6 +142,12 @@ func (c Config) Logger(logger io.Writer) Config {
 // BinaryRepositoryURL set BinaryRepositoryURL to fetch PG Binary in case of Maven proxy
 func (c Config) BinaryRepositoryURL(binaryRepositoryURL string) Config {
 	c.binaryRepositoryURL = binaryRepositoryURL
+	return c
+}
+
+// OwnProcessGroup configures whether the server should be started in its own process group.
+func (c Config) OwnProcessGroup(ownProcessGroup bool) Config {
+	c.ownProcessGroup = ownProcessGroup
 	return c
 }
 

--- a/embedded_postgres.go
+++ b/embedded_postgres.go
@@ -216,6 +216,7 @@ func startPostgres(ep *EmbeddedPostgres) error {
 		"-o", encodeOptions(ep.config.port, ep.config.startParameters))
 	postgresProcess.Stdout = ep.syncedLogger.file
 	postgresProcess.Stderr = ep.syncedLogger.file
+	applyPlatformSpecificOptions(postgresProcess, ep.config)
 
 	if err := postgresProcess.Run(); err != nil {
 		_ = ep.syncedLogger.flush()
@@ -233,6 +234,7 @@ func stopPostgres(ep *EmbeddedPostgres) error {
 		"-D", ep.config.dataPath)
 	postgresProcess.Stderr = ep.syncedLogger.file
 	postgresProcess.Stdout = ep.syncedLogger.file
+	applyPlatformSpecificOptions(postgresProcess, ep.config)
 
 	if err := postgresProcess.Run(); err != nil {
 		return err

--- a/execopts_unix.go
+++ b/execopts_unix.go
@@ -1,0 +1,18 @@
+//go:build !windows
+// +build !windows
+
+package embeddedpostgres
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func applyPlatformSpecificOptions(cmd *exec.Cmd, config Config) {
+	if config.ownProcessGroup {
+		if cmd.SysProcAttr == nil {
+			cmd.SysProcAttr = &syscall.SysProcAttr{}
+		}
+		cmd.SysProcAttr.Setpgid = true
+	}
+}

--- a/execopts_windows.go
+++ b/execopts_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+// +build windows
+
+package embeddedpostgres
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func applyPlatformSpecificOptions(cmd *exec.Cmd, config Config) {
+	if config.ownProcessGroup {
+		if cmd.SysProcAttr == nil {
+			cmd.SysProcAttr = &syscall.SysProcAttr{}
+		}
+		cmd.SysProcAttr.CreationFlags = syscall.CREATE_NEW_PROCESS_GROUP
+	}
+}


### PR DESCRIPTION
In order to handle shutdown cleanly in an app, it's important that the application starting the db instance with `Start` is also the one the calls `Stop` to shut it down.  In the case where an app is running until the user terminates it with a Ctrl-C, the app needs to be able to trap the `SIGINT` and then call `Stop`.

Unfortunately, there's some platform differences in how Ctrl-C is propagated to child processes between platforms.  On Linux/Mac, the interrupt request is passed only to the parent process, but on Windows it is passed to ALL child processes in the same process group as well.  So by the time the parent app goes to call `Stop` - the server is already terminated.

This PR adds a config flag, `OwnProcessGroup` which when passed `true` will make sure that the exec commands that call `pg_ctl` (and in turn, the postgres server itself) are launched in their own process group.  This will change the Ctrl-C behavior on Windows to behave the same as on Linux/Mac.

For good measure, I also set the appropriate flag on Linux/Mac so the behavior is truly consistent in all regards.  It's `SysProcAttr.Setpgid = true` on Linux/Mac, and `SysProcAttr.CreationFlags = syscall.CREATE_NEW_PROCESS_GROUP` on Windows.