### PR TITLE
fix: prevent panic when `*http.Response` is nil

### DIFF
--- a/remote_fetch.go
+++ b/remote_fetch.go
@@ -50,7 +50,9 @@ func defaultRemoteFetchStrategy(remoteFetchHost string, versionStrategy VersionS
 
 		shaDownloadURL := fmt.Sprintf("%s.sha256", jarDownloadURL)
 		shaDownloadResponse, err := http.Get(shaDownloadURL)
-
+		if err != nil {
+			return fmt.Errorf("download sha256 from %s failed: %w", shaDownloadURL, err)
+		}
 		defer closeBody(shaDownloadResponse)()
 
 		if err == nil && shaDownloadResponse.StatusCode == http.StatusOK {

--- a/remote_fetch.go
+++ b/remote_fetch.go
@@ -68,6 +68,9 @@ func defaultRemoteFetchStrategy(remoteFetchHost string, versionStrategy VersionS
 
 func closeBody(resp *http.Response) func() {
 	return func() {
+		if resp == nil {
+			return
+		}
 		if err := resp.Body.Close(); err != nil {
 			log.Fatal(err)
 		}

--- a/remote_fetch.go
+++ b/remote_fetch.go
@@ -70,7 +70,7 @@ func defaultRemoteFetchStrategy(remoteFetchHost string, versionStrategy VersionS
 
 func closeBody(resp *http.Response) func() {
 	return func() {
-		if resp == nil {
+		if resp == nil || resp.Body == nil {
 			return
 		}
 		if err := resp.Body.Close(); err != nil {

--- a/remote_fetch_test.go
+++ b/remote_fetch_test.go
@@ -417,3 +417,9 @@ func Test_defaultRemoteFetchStrategy_whenContentLengthNotSet(t *testing.T) {
 	assert.NoError(t, err)
 	assert.FileExists(t, cacheLocation)
 }
+
+func Test_closeBody_NilResponse(t *testing.T) {
+	assert.NotPanics(t, func() {
+		closeBody(nil)()
+	})
+}


### PR DESCRIPTION
`closeBody` can be called with a nil `*http.Response`, which will panic.

We observed this occurring in our CI: https://github.com/coder/coder/actions/runs/15155935941/job/42610796260

I've also added explicit error handling for sha256 download failures. I'm not quite sure what caused the issue in our CI run above. [Appears to be transient/flaky](https://github.com/coder/coder/actions/runs/15155935941/job/42614262025), so who knows.