### PR TITLE
Ensure target directories exist before extraction and add test for runtime path creation

### DIFF
--- a/decompression.go
+++ b/decompression.go
@@ -21,7 +21,13 @@ func defaultTarReader(xzReader *xz.Reader) (func() (*tar.Header, error), func() 
 }
 
 func decompressTarXz(tarReader func(*xz.Reader) (func() (*tar.Header, error), func() io.Reader), path, extractPath string) error {
-	tempExtractPath, err := os.MkdirTemp(filepath.Dir(extractPath), "temp_")
+	extractDirectory := filepath.Dir(extractPath)
+
+	if err := os.MkdirAll(extractDirectory, os.ModePerm); err != nil {
+		return errorUnableToExtract(path, extractPath, err)
+	}
+
+	tempExtractPath, err := os.MkdirTemp(extractDirectory, "temp_")
 	if err != nil {
 		return errorUnableToExtract(path, extractPath, err)
 	}

--- a/embedded_postgres_test.go
+++ b/embedded_postgres_test.go
@@ -672,6 +672,37 @@ func Test_CachePath(t *testing.T) {
 	}
 }
 
+func Test_CustomRuntimePathCreatedWhenNotPresent(t *testing.T) {
+	runtimeTempDir, err := os.MkdirTemp("", "non_existent_runtime_path")
+	if err != nil {
+		panic(err)
+	}
+
+	defer func() {
+		if err := os.RemoveAll(runtimeTempDir); err != nil {
+			panic(err)
+		}
+	}()
+
+	postgresDataPath := filepath.Join(runtimeTempDir,
+		fmt.Sprintf(".embedded-postgres-go-%d", 4444),
+		"extracted")
+
+	database := NewDatabase(DefaultConfig().
+		RuntimePath(postgresDataPath).
+		BinariesPath(postgresDataPath).
+		DataPath(filepath.Join(postgresDataPath, "data")).
+		Database("hoh"))
+
+	if err := database.Start(); err != nil {
+		shutdownDBAndFail(t, err, database)
+	}
+
+	if err := database.Stop(); err != nil {
+		shutdownDBAndFail(t, err, database)
+	}
+}
+
 func Test_CustomBinariesLocation(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "prepare_database_test")
 	if err != nil {


### PR DESCRIPTION
Ensure target directories exist before extraction and add test for runtime path creation