### PR TITLE
Add support for Postgres 18 and update default version

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,9 @@ This library aims to require as little configuration as possible, favouring over
 | Username            | postgres                                        |
 | Password            | postgres                                        |
 | Database            | postgres                                        |
-| Version             | 15.3.0                                          |
+| Version             | 18.0.0                                          |
 | Encoding            | UTF8                                            |
 | Locale              | C                                               |
-| Version             | 15.3.0                                          |
 | CachePath           | $USER_HOME/.embedded-postgres-go/               |
 | RuntimePath         | $USER_HOME/.embedded-postgres-go/extracted      |
 | DataPath            | $USER_HOME/.embedded-postgres-go/extracted/data |

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ type Config struct {
 // StartTimeout: 15 Seconds
 func DefaultConfig() Config {
 	return Config{
-		version:             V17,
+		version:             V18,
 		port:                5432,
 		database:            "postgres",
 		username:            "postgres",
@@ -153,6 +153,7 @@ type PostgresVersion string
 
 // Predefined supported Postgres versions.
 const (
+	V18 = PostgresVersion("18.0.0")
 	V17 = PostgresVersion("17.5.0")
 	V16 = PostgresVersion("16.9.0")
 	V15 = PostgresVersion("15.13.0")

--- a/platform-test/platform_test.go
+++ b/platform-test/platform_test.go
@@ -14,6 +14,7 @@ import (
 
 func Test_AllMajorVersions(t *testing.T) {
 	allVersions := []embeddedpostgres.PostgresVersion{
+		embeddedpostgres.V18,
 		embeddedpostgres.V17,
 		embeddedpostgres.V16,
 		embeddedpostgres.V15,

--- a/version_strategy_test.go
+++ b/version_strategy_test.go
@@ -105,7 +105,7 @@ func Test_DefaultVersionStrategy_Linux_ARM32V6(t *testing.T) {
 
 	assert.Equal(t, "linux", operatingSystem)
 	assert.Equal(t, "arm32v6", architecture)
-	assert.Equal(t, V17, postgresVersion)
+	assert.Equal(t, V18, postgresVersion)
 }
 
 func Test_DefaultVersionStrategy_Linux_ARM32V7(t *testing.T) {
@@ -121,7 +121,7 @@ func Test_DefaultVersionStrategy_Linux_ARM32V7(t *testing.T) {
 
 	assert.Equal(t, "linux", operatingSystem)
 	assert.Equal(t, "arm32v7", architecture)
-	assert.Equal(t, V17, postgresVersion)
+	assert.Equal(t, V18, postgresVersion)
 }
 
 func Test_DefaultVersionStrategy_Linux_Alpine(t *testing.T) {
@@ -139,7 +139,7 @@ func Test_DefaultVersionStrategy_Linux_Alpine(t *testing.T) {
 
 	assert.Equal(t, "linux", operatingSystem)
 	assert.Equal(t, "amd64-alpine", architecture)
-	assert.Equal(t, V17, postgresVersion)
+	assert.Equal(t, V18, postgresVersion)
 }
 
 func Test_DefaultVersionStrategy_shouldUseAlpineLinuxBuild(t *testing.T) {


### PR DESCRIPTION
Hello!

Since version 18.0.0 was supported at https://github.com/zonkyio/embedded-postgres-binaries, I implemented an update to version 18, referencing https://github.com/fergusstrange/embedded-postgres/pull/159.

I also updated the default values ​​in the README.md, which had been overlooked.
Additionally, there were two "Version" entries in the table, so I removed one.